### PR TITLE
Bugfix for options parsing

### DIFF
--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -679,14 +679,15 @@ class dhcp_serve():
 			# Build the remaining DHCP options by checking type, length and structuring data.
 			pos = 0
 			request['dhcp_options'] = {}
-			while pos < 255:
+			while pos < len(data) <= 312:
 				option = request['options']['bytes'][pos]
 				if option == 255: # End
 					break
-
 				length = request['options']['bytes'][pos+1]
+				if pos + 2 + length > len(data):
+					break
 				data = request['options']['bytes'][pos+2:pos+2+length]
-				pos += 2+length
+				pos += 2 + length
 
 				request['dhcp_options'][f"option {option}"] = { 'binary' : None,
 																'bytes' : data}

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -679,12 +679,13 @@ class dhcp_serve():
 			# Build the remaining DHCP options by checking type, length and structuring data.
 			pos = 0
 			request['dhcp_options'] = {}
-			while pos < len(data) <= 312:
+			while pos < len(data) and pos <= 312:
 				option = request['options']['bytes'][pos]
 				if option == 255: # End
 					break
 				length = request['options']['bytes'][pos+1]
 				if pos + 2 + length > len(data):
+					# out of bounds check
 					break
 				data = request['options']['bytes'][pos+2:pos+2+length]
 				pos += 2 + length


### PR DESCRIPTION
The amount of read bytes from options was too small according to the standard and an IoT device of mine had such a big options field. Hence I fixed it to read up to 312 bytes and added a bounds check if the data is  malformed.
From https://datatracker.ietf.org/doc/html/rfc2131#section-2:
 The 'options' field is now variable length. A DHCP client must be prepared to receive DHCP messages with an 'options' field of at least length 312 octets.