### PR TITLE
Swapped socket logic to support vlan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/*__pycache__
+dhcp_leases.json
+slim.py

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -1075,7 +1075,7 @@ class FrameResponse(pydantic.BaseModel):
 	def validator(cls, frame) -> DHCPResponse:
 		# Assemble the packet headers
 		packet = b''
-		packet += ethernet(src=frame.server.mac, dst=frame.Ethernet.source)
+		packet += ethernet(src=frame.server.mac, dst='ff:ff:ff:ff:ff:ff')
 		if frame.auxillary_data[0].vlan:
 			packet += b'\x81\x00' # Ethernet frame type is 802.1Q VLAN (0x8100)
 			packet += struct.pack('>H', frame.auxillary_data[0].vlan)
@@ -1251,12 +1251,13 @@ class DHCPServer:
 		
 		# if self.bind_to == '255.255.255.255':
 
-		if response.frame.request_frame.auxillary_data[0].vlan:
-			log(f"[-] Broadcasting back response on vlan {response.frame.request_frame.auxillary_data[0].vlan}:", [response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, ('255.255.255.255', 68))
-			self.socket.sendmsg([response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, ('255.255.255.255', 68))
-		else:
-			log(f"[-] Broadcasting back response:", response.frame.data)
-			self.socket.sendto(response.frame.data, ('255.255.255.255', 68))
+		#if response.frame.request_frame.auxillary_data[0].vlan:
+		log(f"Broadcasting DHCP response on vlan {response.frame.request_frame.auxillary_data[0].vlan}:", [response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, (response.frame.request_frame.server.configuration.interface, 68), fg="green", level=logging.INFO)
+		self.socket.sendmsg([response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, (response.frame.request_frame.server.configuration.interface, 68))
+		#else:
+		#	log(f"[-] Broadcasting back response:", response.frame.data)
+		#	self.socket.sendmsg([response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, ('enp3s0', 68))
+		#	#self.socket.sendto(response.frame.data, ('enp3s0', 68))
 		# else:
 		# 	print(f"[-] Sending directly to {addr}")
 		# 	self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -1,16 +1,41 @@
-
-# https://www.netmanias.com/en/post/techdocs/6000/dhcp-network-protocol/understanding-dhcp-relay-agents
-
-import sys, struct, json, abc, os, copy, signal, ipaddress
-import socket, fcntl
+import sys, struct, json, abc, os, copy, signal, binascii, ipaddress #Python v3.3
+import socket, fcntl, ctypes
 from select import epoll, EPOLLIN
-from ctypes import (
-	Structure, Union, POINTER, 
-	pointer, get_errno, cast,
-	c_ushort, c_byte, c_void_p, c_char_p, c_uint, c_int, c_uint16, c_uint32
-)
-import ctypes.util
-import ctypes
+
+ETH_P_ALL = 0x0003
+SOL_PACKET = 263
+PACKET_AUXDATA = 8
+"""
+# Saving this snippet, might come in handy
+	s = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+	if (s < 0) {
+		printf("socket failed: %m");
+		return -1;
+	}
+	soc = s;
+	if (setsockopt(s, SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0)
+		printf("setsockopt packet filter failed: %m");
+
+	printf("setsockopt packet filter");
+
+	
+	strcpy(ifr.ifr_name, interface);
+	if (ioctl(soc, SIOCGIFINDEX, &ifr) < 0) {
+		printf("EthRawSockStart(): ioctl() SIOCGIFINDEX failed! error: %d (NIC: %s)",errno,ifr.ifr_name);
+		return;
+	}
+
+	/* Bind to eth0.50 interface only - this is a private VLAN */
+
+	if (( setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr))) < 0)
+	{
+		perror("Server-setsockopt() error for SO_BINDTODEVICE");
+		printf("%s\n", strerror(errno));
+		close(s);
+		exit(-1);
+	}
+	printf("\n Bind to eth0.... \n");
+"""
 
 class JSON_Typer(json.JSONEncoder):
 	def _encode(self, obj):
@@ -68,113 +93,6 @@ class JSON_Typer(json.JSONEncoder):
 
 	def encode(self, obj):
 		return super(JSON_Typer, self).encode(self._encode(obj))
-
-class struct_sockaddr(Structure):
-	 _fields_ = [
-		('sa_family', c_ushort),
-		('sa_data', c_byte * 14),]
-
-class struct_sockaddr_in(Structure):
-	_fields_ = [
-		('sin_family', c_ushort),
-		('sin_port', c_uint16),
-		('sin_addr', c_byte * 4)]
-
-class struct_sockaddr_in6(Structure):
-	_fields_ = [
-		('sin6_family', c_ushort),
-		('sin6_port', c_uint16),
-		('sin6_flowinfo', c_uint32),
-		('sin6_addr', c_byte * 16),
-		('sin6_scope_id', c_uint32)]
-
-class union_ifa_ifu(Union):
-	_fields_ = [
-		('ifu_broadaddr', POINTER(struct_sockaddr)),
-		('ifu_dstaddr', POINTER(struct_sockaddr)),]
-
-class struct_ifaddrs(Structure):
-	pass
-
-def ifap_iter(ifap):
-	ifa = ifap.contents
-	while True:
-		yield ifa
-		if not ifa.ifa_next:
-			break
-		ifa = ifa.ifa_next.contents
-
-def getfamaddr(sa):
-	family = sa.sa_family
-	addr = None
-	if family == socket.AF_INET:
-		sa = cast(pointer(sa), POINTER(struct_sockaddr_in)).contents
-		addr = socket.inet_ntop(family, sa.sin_addr)
-	elif family == socket.AF_INET6:
-		sa = cast(pointer(sa), POINTER(struct_sockaddr_in6)).contents
-		addr = socket.inet_ntop(family, sa.sin6_addr)
-	return family, addr
-
-class NetworkInterface(object):
-	def __init__(self, name):
-		self.name = name
-		self.index = libc.if_nametoindex(name)
-		self.addresses = {}
-
-	def __str__(self):
-		return "%s [index=%d, IPv4=%s, IPv6=%s]" % (
-			self.name, self.index,
-			self.addresses.get(socket.AF_INET),
-			self.addresses.get(socket.AF_INET6))
-
-def get_network_interfaces():
-	ifap = POINTER(struct_ifaddrs)()
-	result = libc.getifaddrs(pointer(ifap))
-	if result != 0:
-		raise OSError(get_errno())
-	del result
-	try:
-		retval = {}
-		for ifa in ifap_iter(ifap):
-			name = ifa.ifa_name
-			if not name.decode('UTF-8') in retval:
-				retval[name.decode('UTF-8')] = {}
-			try:
-				family, addr = getfamaddr(ifa.ifa_addr.contents)
-				family, subnet = getfamaddr(ifa.ifa_netmask.contents)
-			except ValueError:
-				family, addr, subnet = None, None, None
-
-			if addr:
-				retval[name.decode('UTF-8')][addr] = subnet
-		return retval
-	finally:
-		libc.freeifaddrs(ifap)
-
-struct_ifaddrs._fields_ = [
-	('ifa_next', POINTER(struct_ifaddrs)),
-	('ifa_name', c_char_p),
-	('ifa_flags', c_uint),
-	('ifa_addr', POINTER(struct_sockaddr)),
-	('ifa_netmask', POINTER(struct_sockaddr)),
-	('ifa_ifu', union_ifa_ifu),
-	('ifa_data', c_void_p),]
-
-libc = ctypes.CDLL(ctypes.util.find_library('c'))
-
-def get_ip_address(ifname):
-	if not type(ifname) == bytes:
-		ifname = bytes(ifname, 'UTF-8')
-	s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-	try:
-		return socket.inet_ntoa(fcntl.ioctl(
-			s.fileno(),
-			0x8915,  # SIOCGIFADDR
-			struct.pack('256s', ifname[:15])
-		)[20:24])
-	except:
-		return None
 
 def byte_to_bin(bs, bin_map=None):
 	"""
@@ -237,12 +155,6 @@ def bytes_to_hex(b):
 		s += '{:02X}'.format(i) # Int -> HEX
 	return s
 
-def bytes_to_ip(b):
-	s = ''
-	for i in b:
-		s += '{:d}.'.format(i) # Int -> INT.
-	return ipaddress.ip_address(s[:-1])
-
 def binInt(num):
 	## TODO: Discard, probably not doing what i initially thought it did (results are similar, up to a certain number)
 	##   binInt(53), hexInt(53)  vs  binInt(255), hexInt(255) : <
@@ -280,22 +192,160 @@ def gen_ip(subnet, exludes=[]):
 	#	if not ip in exludes:
 	#		return ip
 	for host in subnet.hosts():
-		if not str(host) in exludes:
+		if not host in exludes:
 			return host
 
-def bytes_to_mac(obj):
+def human_mac(obj):
 	if type(obj) == bytes:
 		return ':'.join([item[2:].zfill(2) for item in binToObj(obj, hex)])
 	else:
-		raise KeyError('Not yet implemented: bytes_to_mac(hex)')
+		raise KeyError('Not yet implemented: human_mac(hex)')
 
 def human_readable(l, separator):
 	return f"{separator}".join([str(x) for x in l])
 
 def ip_to_bytes(ip_obj):
-	if type(ip_obj) == str:
-		ip_obj = ipaddress.ip_address(ip_obj)
 	return struct.pack('>I', int(ip_obj))
+
+def save_local_storage(filename, storage):
+	with open(filename, 'w') as fh:
+		datastore_snapshot = copy.deepcopy(storage)
+		fh.write(json.dumps(datastore_snapshot, indent=4, cls=JSON_Typer))
+
+def load_local_storage(filename):
+	if not filename or not os.path.isfile(filename): return {}
+
+	with open(filename, 'r') as fh:
+		storage = json.load(fh)
+		print(f'[-] Loaded cache: {{"type" : "cache", "loaded" : "{args["cache_dir"]}/{args["cache_db"]}"}}')
+
+	for key in list(storage['leases_by_ip'].keys()):
+		if key == '<internal self reference>': continue
+		if type(key) != ipaddress.IPv4Address:
+			storage['leases_by_ip'][ipaddress.ip_address(key)] = storage['leases_by_ip'][key]
+			del(storage['leases_by_ip'][key])
+
+	for key, val in list(storage['leases_by_mac'].items()):
+		if val == '<internal self reference>' or key == '<internal self reference>': continue
+		if type(val) != ipaddress.IPv4Address:
+			storage['leases_by_mac'][key] = ipaddress.ip_address(storage['leases_by_mac'][key])
+
+	if type(storage['gateway']) != ipaddress.IPv4Address:
+		storage['gateway'] = ipaddress.ip_address(storage['gateway'])
+
+	if type(storage['subnet']) != ipaddress.IPv4Address:
+		storage['subnet'] = ipaddress.ip_network(storage['subnet'])
+
+	if type(storage['pxe_server']) != ipaddress.IPv4Address:
+		storage['pxe_server'] = ipaddress.ip_address(storage['pxe_server'])
+
+	return storage
+
+def parse_auxillary_data(auxillary_data):
+	for message_level, message_type, message_data in auxillary_data:
+		if message_level == SOL_PACKET and message_type == PACKET_AUXDATA:
+			auxdata = tpacket_auxdata.from_buffer_copy(message_data)
+			yield {
+				'status' : auxdata.tp_status,
+				'len' : auxdata.tp_len,
+				'snaplen' : auxdata.tp_snaplen,
+				'mac' : auxdata.tp_mac,
+				'net' : auxdata.tp_net,
+				'vlan' : auxdata.tp_vlan_tci,
+				'padding' : auxdata.tp_padding
+			}
+
+def mac_to_bytes(mac):
+	if not type(mac) == bytes:
+		raise ValueError("mac_to_bytes needs bytes as the mac address")
+	if not b':' in mac:
+		raise ValueError("mac_to_bytes needs : separated mac addresses")
+	return b''.join([struct.pack('B', int(mac_part, 16)) for mac_part in mac.split(b':')])
+
+def ethernet(src, dst):
+	return mac_to_bytes(dst) + mac_to_bytes(src)
+
+def ipv4(src, dst):
+	version_header_length = 0b01000101
+	diff_service_field = 0b00010000
+	total_length = struct.pack('>h', 330)
+	identification = b'\x00\x00'
+	flags = 0b01000000
+	fragmet_offset = b'\x00'
+	ttl = 64
+	protocol = 17 # udp
+	header_checksum = b'\x39\x94'
+	source_address = b''.join([struct.pack('B', int(src_part)) for src_part in src.split('.')])
+	destination_address = b''.join([struct.pack('B', int(dst_part)) for dst_part in dst.split('.')])
+
+	return (
+		struct.pack('B', version_header_length)
+		+ struct.pack('B', diff_service_field)
+		+ total_length
+		+ identification
+		+ struct.pack('B', flags)
+		+ fragmet_offset
+		+ struct.pack('B', ttl)
+		+ struct.pack('B', protocol)
+		+ header_checksum
+		+ source_address
+		+ destination_address
+	)
+
+def udp(src=67, dst=68):
+	return (
+		struct.pack('>h', src)
+		+ struct.pack('>h', dst)
+		+ struct.pack('>h', 310)
+		+ b'\x3f\xa4'
+	)
+
+class tpacket_auxdata(ctypes.Structure):
+	_fields_ = [
+		("tp_status", ctypes.c_uint),
+		("tp_len", ctypes.c_uint),
+		("tp_snaplen", ctypes.c_uint),
+		("tp_mac", ctypes.c_ushort),
+		("tp_net", ctypes.c_ushort),
+		("tp_vlan_tci", ctypes.c_ushort),
+		("tp_padding", ctypes.c_ushort),
+	]
+
+## This is a ctype structure that matches the
+## requirements to set a socket in promisc mode.
+## In all honesty don't know where i found the values :)
+class ifreq(ctypes.Structure):
+		_fields_ = [("ifr_ifrn", ctypes.c_char * 16),
+					("ifr_flags", ctypes.c_short)]
+
+class promisc():
+	def __init__(self, s, interface=b'ens33'):
+		self.s = s
+		self.interface = interface
+		self.ifr = ifreq()
+
+	def on(self):
+		## -- Set up promisc mode:
+		## 
+
+		IFF_PROMISC = 0x100
+		SIOCGIFFLAGS = 0x8913
+		SIOCSIFFLAGS = 0x8914
+
+		self.ifr.ifr_ifrn = self.interface
+
+		fcntl.ioctl(self.s.fileno(), SIOCGIFFLAGS, self.ifr)
+		self.ifr.ifr_flags |= IFF_PROMISC
+
+		fcntl.ioctl(self.s.fileno(), SIOCSIFFLAGS, self.ifr)
+		## ------------- DONE
+
+	def off(self):
+		## Turn promisc mode off:
+		self.ifr.ifr_flags &= ~IFF_PROMISC
+		fcntl.ioctl(self.s.fileno(), SIOCSIFFLAGS, self.ifr)
+		## ------------- DONE
+
 
 class dhcp_option(abc.ABCMeta):
 	"""
@@ -364,27 +414,11 @@ class dhcp_option(abc.ABCMeta):
 		return struct.pack('>H', t)
 
 	@abc.abstractmethod
-	def bootp_flags(request):
-		# https://www.ietf.org/rfc/rfc2131.txt
-		# page 10:
-		#
-		# To work around some clients that cannot accept IP unicast datagrams
-		# before the TCP/IP software is configured ...
-		# [Unicast must not be used]
-		if not int(bin(request['bootp flags']['bytes'][0])[2:][0]):
-			return b'\x00\x00'
-		else:
-			return b'\x80\x00'
+	def bootp_flags():    #Bootp flags: 0x8000 (Broadcast) + reserved flags
+		return b'\x80\x00'
 
 	@abc.abstractmethod
-	def client_ip(request, server_instance): # 0.0.0.0 (We could honor it, but that's a TODO)
-		if request['client ip']['bytes'] != b'\x00\x00\x00\x00':
-			print('Client is asking for IP:', [bytes_to_ip(request['client ip']['bytes'])], 'in leases', server_instance.leases_by_ip)
-			if (ip := bytes_to_ip(request['client ip']['bytes'])) in server_instance.leases_by_ip:
-				print('IP was in leases')
-				if (mac := bytes_to_mac(request['client mac']['bytes'])) in server_instance.leases_by_mac:
-					print(f"IP {ip} and MAC {mac} was identified as a previous lease: {server_instance.leases_by_mac[mac]}")
-					#if ip == server_instance.leases_by_mac[mac]:
+	def client_ip(request): # 0.0.0.0 (We could honor it, but that's a TODO)
 		return b'\x00\x00\x00\x00'
 
 	@abc.abstractmethod
@@ -517,102 +551,44 @@ class dhcp_option(abc.ABCMeta):
 		rt = struct.pack('>I', t)
 		return binInt(59)+struct.pack('B', len(rt))+rt # Rebinding Time Value
 
-class Leases():
-	def __init__(self, subnet, ip_leases=None, mac_leases=None):
-		if not ip_leases:
-			ip_leases = {}
-		if not mac_leases:
-			mac_leases = {}
-
-		self.subnet = subnet
-		self.leases_by_mac = mac_leases
-		self.leases_by_ip = ip_leases
-
-	def lease(self, ip, mac):
-		self.leases_by_ip[str(ip)] = mac
-		self.leases_by_mac[mac] = str(ip)
-
-	def release(self, address):
-		try:
-			ip = ipaddress.ip_address(address)
-			mac = self.leases_by_ip.get(ip)
-		except ValueError:
-			if type(address) == bytes:
-				address = bytes_to_mac(address)
-
-			mac = address
-			ip = self.leases_by_mac.get(mac)
-		
-		if mac and ip:
-			del(self.leases_by_ip[ip])
-			del(self.leases_by_mac[mac])
-
-	def save(self, path):
-		with open(path, 'w') as output:
-			output.write(json.dumps({
-				'leases_by_ip' : self.leases_by_ip,
-				'leases_by_mac' : self.leases_by_mac
-			}))
-
-	def load(self, path):
-		if os.path.isfile((path := os.path.abspath(path))):
-			with open(path, 'r') as fh:
-				data = json.load(fh)
-				self.leases_by_mac = data['leases_by_mac']
-				self.leases_by_ip = data['leases_by_ip']
-
-	@property
-	def available_ip(self):
-		for host in self.subnet.hosts():
-			print(str(host), self.leases_by_ip)
-			if not str(host) in self.leases_by_ip:
-				return host
-
 class dhcp_serve():
-	def __init__(self, lease_db, *args, **kwargs):
+	def __init__(self, *args, **kwargs):
 		if not 'interface' in kwargs:
 			raise KeyError('dhcp_server() requires at least a interface=X to be given.')
 
-		if not kwargs.get('subnet'):
-			raise KeyError(f"dhcp_server() requires a valid subnet to be given: {kwargs['subnet']}")
+		## Cache variables:
+		self.leases_by_mac = {}
+		self.leases_by_ip = {}
 
 		## Update our self.variable = value references.
 		for var, val in kwargs.items():
 			self.__dict__[var] = val
 
-		self.lease_db = lease_db
-
 		with open(f'/sys/class/net/{self.interface}/address', 'r') as fh:
 			self.mac = fh.read().strip()
 
-		if self.is_gateway and self.mac not in self.lease_db.leases_by_mac and self.gateway not in self.lease_db.leases_by_ip:
+		if self.is_gateway and self.mac not in self.leases_by_mac and self.gateway not in self.leases_by_ip:
 			print(f'[-] We are the gateway: {{"gateway" : "{self.gateway}", "mac" : "{self.mac}"}}')
-			self.lease_db.leases_by_ip[self.gateway] = self.mac
-			self.lease_db.leases_by_mac[self.mac] = self.gateway
+			self.leases_by_ip[self.gateway] = self.mac
+			self.leases_by_mac[self.mac] = self.gateway
 		else:
 			print(f'[-] Gateway MAC unknown: {{"gateway" : "{self.gateway}", "mac" : "unknown"}}')
-			self.lease_db.leases_by_ip[self.gateway] = '00:00:00:00:00:00'
-			self.lease_db.leases_by_mac['00:00:00:00:00:00'] = self.gateway
-
-		print(f"Initiated the server with leases: {self.lease_db.leases_by_mac} and {self.lease_db.leases_by_ip}")
+			self.leases_by_ip[self.gateway] = '00:00:00:00:00:00'
+			self.leases_by_mac['00:00:00:00:00:00'] = self.gateway
 		
-		#dhcp_option.client_ip({'client ip' : {'bytes' : b'\xc0\xa8\x00\x01'}, 'client mac' : {'bytes' : b'\xb6\x35\xbb\xef\xd1\x7b'}}, self)
-		#dhcp_option.client_ip({'client ip' : {'bytes' : b'\xff\xff\x00\x00'}, 'client mac' : {'bytes' : b'\x00\x00\x00\x00\x00\x00'}}, self)
-		#exit(0)
+		# https://github.com/Torxed/python-socket/blob/main/pysocket/pysocket.py
+		self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(ETH_P_ALL))
+		self.socket.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
+		promisciousMode = promisc(self.socket, bytes(kwargs['interface'], 'UTF-8'))
+		promisciousMode.on()
 
-		self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
-
-		## https://www.freepascal.org/docs-html/current/rtl/sockets/index-2.html
-		self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-		self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-		## Not sure we need this:
-		self.socket.setsockopt(socket.SOL_SOCKET, 25, bytes(kwargs['interface'], 'UTF-8')+b'\0') ## http://fxr.watson.org/fxr/source/net/wanrouter/af_wanpipe.c?v=linux-2.6
-		self.socket.bind((bytes(kwargs['bind_to'], 'UTF-8'), 67)) # And lets listen on port 67 broadcasts (UDP)
 		self.main_so_id = self.socket.fileno()
-		print(f'[-] Bound to: {{"interface" : "{kwargs["interface"]}", "address" : "{kwargs["bind_to"]}", "port" : 67}}')
+		print(f'[-] Bound to: {{"interface" : "{kwargs["interface"]}", "address" : "255.255.255.255", "port" : 67}}')
 
 		self.pollobj = epoll()
 		self.pollobj.register(self.main_so_id, EPOLLIN)
+
+		self.temp = []
 
 
 	def poll(self, timeout=0.001, fileno=None):
@@ -625,15 +601,15 @@ class dhcp_serve():
 		self.socket.close()
 
 	def get_lease(self, mac):
-		if mac in self.lease_db.leases_by_mac:
-			return self.lease_db.leases_by_mac[mac]
+		if mac in self.leases_by_mac:
+			return self.leases_by_mac[mac]
 		else:
 			return None
 
 	def parse(self):
 		# The struct just maps how many bytes (not bits) per section in a DHCP request.
 		# A graphic overview can be found here: https://tools.ietf.org/html/rfc2131#section-2
-		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4]
+		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4, 3]
 		# We then use that struct map to place the values into a dictionary with these keys (in order):
 		dhcp_protocol = ['msg type', 'hw type', 'hw addr len', 'hops',
 						 'transaction id',
@@ -647,14 +623,60 @@ class dhcp_serve():
 						 'server hostname',
 						 'boot file',
 						 'magic cookie',
-						 #'option 53', # This is dangerous to assume
-						 'options']
+						 'option 53', # This is dangerous to assume
+						 'other']
 
 		if self.poll():
-			data, addr = self.socket.recvfrom(8192) # Could potentially lower tihs value, not sure if that would gain anything tho.
+			data, auxillary_data_raw, flags, addr = self.socket.recvmsg(65535, socket.CMSG_LEN(4096))
+			
+			if not data:
+				return
+
+			auxillary_data = []
+			if auxillary_data_raw:
+				auxillary_data = list(parse_auxillary_data(auxillary_data_raw))[0]
+
+			ethernet_data = data[0:14]
+			ethernet_segments = struct.unpack("!6s6s2s", ethernet_data)
+
+			mac_dest, mac_source = (binascii.hexlify(mac) for mac in ethernet_segments[:2])
+			mac_source = b':'.join(mac_source[i:i+2] for i in range(0, len(mac_source), 2))
+			mac_dest = b':'.join(mac_dest[i:i+2] for i in range(0, len(mac_dest), 2))
+			frame_type = binascii.hexlify(ethernet_segments[2])
+			
+			ip = data[14:34]
+			ip_segments = struct.unpack("!12s4s4s", ip)
+
+			ip_source, ip_dest = (socket.inet_ntoa(section) for section in ip_segments[1:3])
+
+			udp_data = data[34:42]
+			udp_segments = struct.unpack("!hhh2s", udp_data)
+			source_port, destination_port, udp_payload_len, udp_checksum = udp_segments
+
+			# IPv4 == \x08\x00
+			if frame_type != b'0800':
+				return
+
+			if not mac_dest == b'ff:ff:ff:ff:ff:ff':
+				# We only accept broadcasts
+				return
+
+			if destination_port != 67:
+				return
+
+			# print('MAC Source:', mac_source)
+			# print('MAC Dest:', mac_dest)
+			# print('Frame Type:', frame_type)
+			# print(auxillary_data)
+			# print(binascii.hexlify(data))
+
+			# print('IP Source:', ip_source)
+			# print('IP Dest:', ip_dest)
+
+			# print('UDP:', source_port, destination_port)
 
 			## Convert and slot the data into the binary map representation
-			binary = list(byte_to_bin(data, bin_map=dhcp_packet_struct))
+			binary = list(byte_to_bin(data[42:], bin_map=dhcp_packet_struct))
 
 			## Convert the binary representation into the protocol map
 			request = {}
@@ -662,49 +684,35 @@ class dhcp_serve():
 				request[dhcp_protocol[index]] = {'binary' : binary[index], 'bytes' : bin_str_to_byte(binary[index]), 'hex' : None}
 				request[dhcp_protocol[index]]['hex'] = bytes_to_hex(request[dhcp_protocol[index]]['bytes'])
 
-			print(f'[+] Request from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
-			if str(bytes_to_ip(request['relay agent']['bytes'])) != addr[0]:
-				if self.valid_relays.get(addr[0]) != str(bytes_to_ip(request['relay agent']['bytes'])):
-					print(f"[!] Inconsistency in relayed message, sender is not the same as the relay IP: Sender={addr[0]}, Relay-Agent={bytes_to_ip(request['relay agent']['bytes'])} ")
-					return None
-			print(f"[ ]  Relay via {bytes_to_ip(request['relay agent']['bytes'])}")
+			print(f'[+] Packet from: {{"mac": "{human_mac(request["client mac"]["bytes"])}"}}')
 
 			## Check if we've white listed clients,
 			## and if so, check if this client isn't allowed and return nothing on the cable.
 			if 'filter_clients' in args and args['filter_clients']:
-				if not bytes_to_mac(request["client mac"]["bytes"]) in args['filter_clients']:
-					print(f'[ ] Request ignored: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
+				if not human_mac(request["client mac"]["bytes"]) in args['filter_clients']:
+					print(f'[ ] Request ignored: {{"mac": "{human_mac(request["client mac"]["bytes"])}"}}')
 					return
 
-			# Build the remaining DHCP options by checking type, length and structuring data.
-			pos = 0
+			## Extract the DHCP options from the client
+			requests_dhcp_options = request['other']['binary']
+			num_of_dhcp_options = ord(bin_str_to_byte([requests_dhcp_options[1]]))
 			request['dhcp_options'] = {}
-			while pos < len(data) and pos <= 312:
-				option = request['options']['bytes'][pos]
-				if option == 255: # End
-					break
-				length = request['options']['bytes'][pos+1]
-				if pos + 2 + length > len(data):
-					# out of bounds check
-					break
-				data = request['options']['bytes'][pos+2:pos+2+length]
-				pos += 2 + length
-
-				request['dhcp_options'][f"option {option}"] = { 'binary' : None,
-																'bytes' : data}
+			for item in range(num_of_dhcp_options):
+				request['dhcp_options'][item] = { 'binary' : requests_dhcp_options[item],
+												  'bytes' : bin_str_to_byte([requests_dhcp_options[item]])}
 
 			## Got all the parsing and processing done.
 			## Time ot build a response if the requested packet was DHCP request of some kind.
 			packet = b''
 			if request['msg type']['bytes'][-1] == 1: # Message type: Boot request (1)
-				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[ ] DHCP Discover from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "type" : "DHCP_DISCOVER"}}')
-				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[ ] DHCP Request for IP from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "ip" : "<ignored>", "type" : "DHCP_REQUEST"}}')
+				if request['option 53']['bytes'][-1] == 1: # DHCP Discover
+					print(f'[ ] DHCP Discover from: {{"mac": "{human_mac(request["client mac"]["bytes"])}", "type" : "DHCP_DISCOVER"}}')
+				if request['option 53']['bytes'][-1] == 3: # DHCP Request
+					print(f'[ ] DHCP Request for IP from: {{"mac": "{human_mac(request["client mac"]["bytes"])}", "ip" : "<ignored>", "type" : "DHCP_REQUEST"}}')
 
 				## Check lease time for the specific mac
 				## If we don't find a lease, begin the "generate new IP process".
-				mac = bytes_to_mac(request["client mac"]["bytes"])
+				mac = human_mac(request["client mac"]["bytes"])
 				if not (leased_ip := self.get_lease(mac)):
 					# The mac is filtered, and contains a static IP lease definition
 					if args['filter_clients'] and mac in args['filter_clients'] and args['filter_clients'][mac].count('.'):
@@ -712,30 +720,36 @@ class dhcp_serve():
 						print(f'[ ] Staticly giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "STATIC_DHCP_OFFER"}}')
 					# Otherwise, generate a IP from the total pool of available IP's
 					else:
-						leased_ip = self.lease_db.available_ip
+						leased_ip = gen_ip(self.subnet, self.leases_by_ip)
 						print(f'[ ] Dynamically giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "DYNAMIC_DHCP_OFFER"}}')
 					
 					if leased_ip:
-						self.lease_db.lease(leased_ip, mac)
-						#self.lease_db.leases_by_mac[mac] = leased_ip
-						#self.lease_db.leases_by_ip[leased_ip] = mac
+						self.leases_by_mac[mac] = leased_ip
+						self.leases_by_ip[leased_ip] = mac
 					else:
 						raise ValueError('TODO: Out of IP addresses..') # TODO: make a clean "continue" / "check if old leases expired"
 				# There was a pre-existing lease, using that lease:
 				else:
 					print(f'[ ] Giving cached: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "CACHED_DHCP_OFFER"}}')
 
+				# Assemble the packet headers
+				packet += ethernet(src=b'00:51:82:11:22:00', dst=mac_source) + b'\x81\x00'
+				packet += struct.pack('>h', 0b0000000000000010) + b'\x08\x00'# vlan(struct.pack('>h', 0b0000000000000010) + b'\x08\x00')
+				packet += ipv4(src='172.23.0.1', dst='255.255.255.255')
+				packet += udp(src=67, dst=68)
+
+				# Assemble the DHCP specific payload
 				packet += dhcp_option.dhcp_offer()
 				packet += dhcp_option.hardware_type('ethernet')
 				packet += dhcp_option.hardware_address_length(6)
-				packet += dhcp_option.hops(request['hops']['bytes'][0]+1)
+				packet += dhcp_option.hops(0)
 				packet += dhcp_option.trasnaction_id(request)
 				packet += dhcp_option.seconds_elapsed(0)
-				packet += dhcp_option.bootp_flags(request)
-				packet += dhcp_option.client_ip(request, self)
+				packet += dhcp_option.bootp_flags()
+				packet += dhcp_option.client_ip(request)
 				packet += dhcp_option.offered_ip(leased_ip)
 				packet += dhcp_option.next_server(self.pxe_server) # 0.0.0.0 == None
-				packet += dhcp_option.relay_agent(bytes_to_ip(request['relay agent']['bytes']))
+				packet += dhcp_option.relay_agent(ipaddress.ip_address('0.0.0.0'))
 				packet += dhcp_option.client_mac(request)
 				packet += dhcp_option.client_addr_padding()
 				packet += dhcp_option.server_host_name(request)
@@ -744,16 +758,16 @@ class dhcp_serve():
 
 				## This is basically what differs in a basic basic DHCP sequence,
 				## the message type recieved and matching response. At least for a basic IP request/handshake.
-				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
+				if request['option 53']['bytes'][-1] == 1: # DHCP Discover
+					print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.leases_by_mac[mac]}"}}')
 					packet += dhcp_option.TYPE('OFFER')
-				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
+				if request['option 53']['bytes'][-1] == 3: # DHCP Request
+					print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.leases_by_mac[mac]}"}}')
 					packet += dhcp_option.TYPE('ACK')
 				
 				# Slap on the clients trasnacation identifier so it knows
 				# we responded to the request and not some other request it made.	
-				packet += dhcp_option.identifier(self.bind_to)
+				packet += dhcp_option.identifier(self.gateway)
 				
 				# We don't honor these, so we're generous with them:
 				packet += dhcp_option.lease_time(43200)
@@ -776,35 +790,17 @@ class dhcp_serve():
 				packet += b'\xff'   #End Option
 
 			if len(packet) > 0:
-				# If the 'giaddr' field in a DHCP message from a client is non-zero,
-				# the server sends any return messages to the 'DHCP server' port on the
-				# BOOTP relay agent whose address appears in 'giaddr'. If the 'giaddr'
-				# field is zero and the 'ciaddr' field is nonzero, then the server
-				# unicasts DHCPOFFER and DHCPACK messages to the address in 'ciaddr'.
-				# If 'giaddr' is zero and 'ciaddr' is zero, and the broadcast bit is
-				# set, then the server broadcasts DHCPOFFER and DHCPACK messages to
-				# 0xffffffff. If the broadcast bit is not set and 'giaddr' is zero and
-				# 'ciaddr' is zero, then the server unicasts DHCPOFFER and DHCPACK
-				# messages to the client's hardware address and 'yiaddr' address.  In
-				# all cases, when 'giaddr' is zero, the server broadcasts any DHCPNAK
-				# messages to 0xffffffff.
-				if self.bind_to == '255.255.255.255':
-					print(f"[-] Broadcasting back response")
-					self.socket.sendto(packet, ('255.255.255.255', 68))
-				else:
-					print(f"[-] Sending directly to {addr}")
-					self.socket.sendto(packet, (addr[0], 67))
+				import array
+				socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(ETH_P_ALL)
+				print(auxillary_data_raw, auxillary_data)
+				self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)
 
 				if self.cache_db:
-					self.lease_db.save(self.cache_dir + '/' + self.cache_db)
-					#save_local_storage(self.cache_dir + '/' + self.cache_db, self.lease_db)
+					save_local_storage(self.cache_dir + '/' + self.cache_db, {**self.__dict__, 'socket' : None, 'pollobj' : None})
 
 if __name__ == '__main__':
-	instances = []
-
 	def sig_handler(signal, frame):
-		for instance in instances:
-			instance.close()
+		dhcp.close()
 		exit(0)
 	signal.signal(signal.SIGINT, sig_handler)
 
@@ -829,7 +825,7 @@ if __name__ == '__main__':
 		print('Usage: ')
 		print(' --interface=eth0          (mandatory)')
 		print(' --subnet=192.168.1.0/24   (default)')
-		print(' --gateway=192.168.1.1     (default is the first ip on --interface)')
+		print(' --gateway=192.168.1.1     (default)')
 		print(' --pxe_bin=ipxe.efi')
 		print(' --pxe_dir=/srv/pxe/')
 		print(' --filter_clients=\'{"de:ad:be:ef:00:01" : true, "de:ad:be:ef:00:02" : "192.168.1.10"}\'')
@@ -837,7 +833,9 @@ if __name__ == '__main__':
 	
 	if not 'cache_dir' in args: args['cache_dir'] = './'
 	if not 'cache_db' in args: args['cache_db'] = None
-	if not 'subnet' in args: args['subnet'] = None
+	args = {**load_local_storage(f"{args['cache_dir']}/{args['cache_db']}"), **args}
+
+	if not 'subnet' in args: args['subnet'] = '192.168.1.0'
 	if not 'netmask' in args: args['netmask'] = '255.255.255.0' # Optional, if it's given on the subnet definition.
 	if not 'gateway' in args: args['gateway'] = None # Takes the first host of the subnet by default
 	if not 'is_gateway' in args: args['is_gateway'] = False
@@ -845,28 +843,13 @@ if __name__ == '__main__':
 	if not 'pxe_bin' in args: args['pxe_bin'] = None # Point toward a efi file, for instance: '/ipxe.efi'
 	if not 'pxe_dir' in args: args['pxe_dir'] = './'# './pxe_files'
 	if not 'pxe_config' in args: args['pxe_config'] = 'loader/loader.conf'
-	if not 'multi_bind' in args: args['multi_bind'] = True
-	if not 'valid_relays' in args: args['valid_relays'] = '{}'
-	if not 'pxe_server' in args: args['pxe_server'] = '0.0.0.0'
+	if not 'pxe_server' in args:
+		if args['pxe_bin']:
+			args['pxe_server'] = args['gateway']
+		else:
+			args['pxe_server'] = '0.0.0.0'
 	if not 'filter_clients' in args: args['filter_clients'] = '{}' # JSON structure of clients
-	args['valid_relays'] = json.loads(args['valid_relays'])
 
-	if not args['gateway'] and args['is_gateway']:
-		args['gateway'] = get_ip_address(args['interface'])
-		if not args['gateway']:
-			raise ValueError(f"slimDHCP could not detect a valid IP address on {args['interface']}, and --is_gateway was given, which requires us to be able to recieve traffic. This in turn means we can't guess a subnet to use.")
-	if args['multi_bind'] and get_ip_address(args['interface']) is None:
-		raise ValueError(f"slimDHCP was asked to bind to multiple IP's, however the interface doesn't have an IP which means we can only listen to broadcast traffic. Either do not attempt --multi_bind or assign a valid IP to the --interface {args['interface']}")
-
-	if not args['subnet'] and not args['gateway']:
-		args['subnet'] = '192.168.1.0'
-	elif not args['subnet']:
-		ip_information = get_network_interfaces().get(args['interface'], {})
-		first_available_ip = list(ip_information.keys())[0]
-		matching_subnet_mask = ip_information[first_available_ip]
-		args['subnet'] = str(ipaddress.ip_network(f"{first_available_ip}/{matching_subnet_mask}", strict=False).network_address)
-		if args['netmask'] != matching_subnet_mask:
-			raise ValueError(f"A subnet was autodetected as {args['subnet']}, but the autodetected netmask of {matching_subnet_mask} does not match the user specified --netmask.")
 
 	## Convert arguments to workable elements:
 	if type(args['dns_servers']) == str:
@@ -887,15 +870,7 @@ if __name__ == '__main__':
 			args['gateway'] = host
 			break
 
-	lease_database = Leases(args['subnet'])
-	if args['cache_dir'] and args['cache_db']:
-		lease_database.load(f"{args['cache_dir']}/{args['cache_db']}")
-
-	if args['multi_bind']:
-		instances.append(dhcp_serve(lease_db=lease_database, bind_to=get_ip_address(args['interface']), **{**args, 'gateway' : get_ip_address(args['interface'])}))
-	instances.append(dhcp_serve(lease_db=lease_database, bind_to='255.255.255.255', **args))
-
+	dhcp = dhcp_serve(**args)
 	while 1:
-		for instance in instances:
-			if instance.poll():
-				instance.parse()
+		if dhcp.poll():
+			dhcp.parse()

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -513,7 +513,7 @@ class dhcp_fields(abc.ABCMeta):
 
 	@abc.abstractmethod
 	def transaction_id(identifier :int):
-		return struct.pack('>I', identifier)
+		return struct.pack('>i', identifier)
 
 	@abc.abstractmethod
 	def seconds_elapsed(t=0):

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -1,41 +1,21 @@
-import sys, struct, json, abc, os, copy, signal, binascii, ipaddress #Python v3.3
-import socket, fcntl, ctypes
-from select import epoll, EPOLLIN
 
+# https://www.netmanias.com/en/post/techdocs/6000/dhcp-network-protocol/understanding-dhcp-relay-agents
+
+import sys, struct, json, abc, os, copy, signal, ipaddress
+import socket, fcntl
+from select import epoll, EPOLLIN
+from ctypes import (
+	Structure, Union, POINTER, 
+	pointer, get_errno, cast,
+	c_ushort, c_byte, c_void_p, c_char_p, c_uint, c_int, c_uint16, c_uint32
+)
+import ctypes.util
+import ctypes
+
+# Static values to subscribe to aux data on individual packets
 ETH_P_ALL = 0x0003
 SOL_PACKET = 263
 PACKET_AUXDATA = 8
-"""
-# Saving this snippet, might come in handy
-	s = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
-	if (s < 0) {
-		printf("socket failed: %m");
-		return -1;
-	}
-	soc = s;
-	if (setsockopt(s, SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0)
-		printf("setsockopt packet filter failed: %m");
-
-	printf("setsockopt packet filter");
-
-	
-	strcpy(ifr.ifr_name, interface);
-	if (ioctl(soc, SIOCGIFINDEX, &ifr) < 0) {
-		printf("EthRawSockStart(): ioctl() SIOCGIFINDEX failed! error: %d (NIC: %s)",errno,ifr.ifr_name);
-		return;
-	}
-
-	/* Bind to eth0.50 interface only - this is a private VLAN */
-
-	if (( setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr))) < 0)
-	{
-		perror("Server-setsockopt() error for SO_BINDTODEVICE");
-		printf("%s\n", strerror(errno));
-		close(s);
-		exit(-1);
-	}
-	printf("\n Bind to eth0.... \n");
-"""
 
 class JSON_Typer(json.JSONEncoder):
 	def _encode(self, obj):
@@ -93,6 +73,113 @@ class JSON_Typer(json.JSONEncoder):
 
 	def encode(self, obj):
 		return super(JSON_Typer, self).encode(self._encode(obj))
+
+class struct_sockaddr(Structure):
+	 _fields_ = [
+		('sa_family', c_ushort),
+		('sa_data', c_byte * 14),]
+
+class struct_sockaddr_in(Structure):
+	_fields_ = [
+		('sin_family', c_ushort),
+		('sin_port', c_uint16),
+		('sin_addr', c_byte * 4)]
+
+class struct_sockaddr_in6(Structure):
+	_fields_ = [
+		('sin6_family', c_ushort),
+		('sin6_port', c_uint16),
+		('sin6_flowinfo', c_uint32),
+		('sin6_addr', c_byte * 16),
+		('sin6_scope_id', c_uint32)]
+
+class union_ifa_ifu(Union):
+	_fields_ = [
+		('ifu_broadaddr', POINTER(struct_sockaddr)),
+		('ifu_dstaddr', POINTER(struct_sockaddr)),]
+
+class struct_ifaddrs(Structure):
+	pass
+
+def ifap_iter(ifap):
+	ifa = ifap.contents
+	while True:
+		yield ifa
+		if not ifa.ifa_next:
+			break
+		ifa = ifa.ifa_next.contents
+
+def getfamaddr(sa):
+	family = sa.sa_family
+	addr = None
+	if family == socket.AF_INET:
+		sa = cast(pointer(sa), POINTER(struct_sockaddr_in)).contents
+		addr = socket.inet_ntop(family, sa.sin_addr)
+	elif family == socket.AF_INET6:
+		sa = cast(pointer(sa), POINTER(struct_sockaddr_in6)).contents
+		addr = socket.inet_ntop(family, sa.sin6_addr)
+	return family, addr
+
+class NetworkInterface(object):
+	def __init__(self, name):
+		self.name = name
+		self.index = libc.if_nametoindex(name)
+		self.addresses = {}
+
+	def __str__(self):
+		return "%s [index=%d, IPv4=%s, IPv6=%s]" % (
+			self.name, self.index,
+			self.addresses.get(socket.AF_INET),
+			self.addresses.get(socket.AF_INET6))
+
+def get_network_interfaces():
+	ifap = POINTER(struct_ifaddrs)()
+	result = libc.getifaddrs(pointer(ifap))
+	if result != 0:
+		raise OSError(get_errno())
+	del result
+	try:
+		retval = {}
+		for ifa in ifap_iter(ifap):
+			name = ifa.ifa_name
+			if not name.decode('UTF-8') in retval:
+				retval[name.decode('UTF-8')] = {}
+			try:
+				family, addr = getfamaddr(ifa.ifa_addr.contents)
+				family, subnet = getfamaddr(ifa.ifa_netmask.contents)
+			except ValueError:
+				family, addr, subnet = None, None, None
+
+			if addr:
+				retval[name.decode('UTF-8')][addr] = subnet
+		return retval
+	finally:
+		libc.freeifaddrs(ifap)
+
+struct_ifaddrs._fields_ = [
+	('ifa_next', POINTER(struct_ifaddrs)),
+	('ifa_name', c_char_p),
+	('ifa_flags', c_uint),
+	('ifa_addr', POINTER(struct_sockaddr)),
+	('ifa_netmask', POINTER(struct_sockaddr)),
+	('ifa_ifu', union_ifa_ifu),
+	('ifa_data', c_void_p),]
+
+libc = ctypes.CDLL(ctypes.util.find_library('c'))
+
+def get_ip_address(ifname):
+	if not type(ifname) == bytes:
+		ifname = bytes(ifname, 'UTF-8')
+	s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+	try:
+		return socket.inet_ntoa(fcntl.ioctl(
+			s.fileno(),
+			0x8915,  # SIOCGIFADDR
+			struct.pack('256s', ifname[:15])
+		)[20:24])
+	except:
+		return None
 
 def byte_to_bin(bs, bin_map=None):
 	"""
@@ -155,6 +242,12 @@ def bytes_to_hex(b):
 		s += '{:02X}'.format(i) # Int -> HEX
 	return s
 
+def bytes_to_ip(b):
+	s = ''
+	for i in b:
+		s += '{:d}.'.format(i) # Int -> INT.
+	return ipaddress.ip_address(s[:-1])
+
 def binInt(num):
 	## TODO: Discard, probably not doing what i initially thought it did (results are similar, up to a certain number)
 	##   binInt(53), hexInt(53)  vs  binInt(255), hexInt(255) : <
@@ -192,54 +285,22 @@ def gen_ip(subnet, exludes=[]):
 	#	if not ip in exludes:
 	#		return ip
 	for host in subnet.hosts():
-		if not host in exludes:
+		if str(host) not in exludes:
 			return host
 
-def human_mac(obj):
+def bytes_to_mac(obj):
 	if type(obj) == bytes:
 		return ':'.join([item[2:].zfill(2) for item in binToObj(obj, hex)])
 	else:
-		raise KeyError('Not yet implemented: human_mac(hex)')
+		raise KeyError('Not yet implemented: bytes_to_mac(hex)')
 
 def human_readable(l, separator):
 	return f"{separator}".join([str(x) for x in l])
 
 def ip_to_bytes(ip_obj):
+	if type(ip_obj) == str:
+		ip_obj = ipaddress.ip_address(ip_obj)
 	return struct.pack('>I', int(ip_obj))
-
-def save_local_storage(filename, storage):
-	with open(filename, 'w') as fh:
-		datastore_snapshot = copy.deepcopy(storage)
-		fh.write(json.dumps(datastore_snapshot, indent=4, cls=JSON_Typer))
-
-def load_local_storage(filename):
-	if not filename or not os.path.isfile(filename): return {}
-
-	with open(filename, 'r') as fh:
-		storage = json.load(fh)
-		print(f'[-] Loaded cache: {{"type" : "cache", "loaded" : "{args["cache_dir"]}/{args["cache_db"]}"}}')
-
-	for key in list(storage['leases_by_ip'].keys()):
-		if key == '<internal self reference>': continue
-		if type(key) != ipaddress.IPv4Address:
-			storage['leases_by_ip'][ipaddress.ip_address(key)] = storage['leases_by_ip'][key]
-			del(storage['leases_by_ip'][key])
-
-	for key, val in list(storage['leases_by_mac'].items()):
-		if val == '<internal self reference>' or key == '<internal self reference>': continue
-		if type(val) != ipaddress.IPv4Address:
-			storage['leases_by_mac'][key] = ipaddress.ip_address(storage['leases_by_mac'][key])
-
-	if type(storage['gateway']) != ipaddress.IPv4Address:
-		storage['gateway'] = ipaddress.ip_address(storage['gateway'])
-
-	if type(storage['subnet']) != ipaddress.IPv4Address:
-		storage['subnet'] = ipaddress.ip_network(storage['subnet'])
-
-	if type(storage['pxe_server']) != ipaddress.IPv4Address:
-		storage['pxe_server'] = ipaddress.ip_address(storage['pxe_server'])
-
-	return storage
 
 def parse_auxillary_data(auxillary_data):
 	for message_level, message_type, message_data in auxillary_data:
@@ -346,7 +407,6 @@ class promisc():
 		fcntl.ioctl(self.s.fileno(), SIOCSIFFLAGS, self.ifr)
 		## ------------- DONE
 
-
 class dhcp_option(abc.ABCMeta):
 	"""
 	This class abstracts the build process of using struct.pack() to
@@ -414,11 +474,27 @@ class dhcp_option(abc.ABCMeta):
 		return struct.pack('>H', t)
 
 	@abc.abstractmethod
-	def bootp_flags():    #Bootp flags: 0x8000 (Broadcast) + reserved flags
-		return b'\x80\x00'
+	def bootp_flags(request):
+		# https://www.ietf.org/rfc/rfc2131.txt
+		# page 10:
+		#
+		# To work around some clients that cannot accept IP unicast datagrams
+		# before the TCP/IP software is configured ...
+		# [Unicast must not be used]
+		if not int(bin(request['bootp flags']['bytes'][0])[2:][0]):
+			return b'\x00\x00'
+		else:
+			return b'\x80\x00'
 
 	@abc.abstractmethod
-	def client_ip(request): # 0.0.0.0 (We could honor it, but that's a TODO)
+	def client_ip(request, server_instance): # 0.0.0.0 (We could honor it, but that's a TODO)
+		if request['client ip']['bytes'] != b'\x00\x00\x00\x00':
+			print('Client is asking for IP:', [bytes_to_ip(request['client ip']['bytes'])], 'in leases', server_instance.leases_by_ip)
+			if (ip := bytes_to_ip(request['client ip']['bytes'])) in server_instance.leases_by_ip:
+				print('IP was in leases')
+				if (mac := bytes_to_mac(request['client mac']['bytes'])) in server_instance.leases_by_mac:
+					print(f"IP {ip} and MAC {mac} was identified as a previous lease: {server_instance.leases_by_mac[mac]}")
+					#if ip == server_instance.leases_by_mac[mac]:
 		return b'\x00\x00\x00\x00'
 
 	@abc.abstractmethod
@@ -551,30 +627,84 @@ class dhcp_option(abc.ABCMeta):
 		rt = struct.pack('>I', t)
 		return binInt(59)+struct.pack('B', len(rt))+rt # Rebinding Time Value
 
+class Leases():
+	def __init__(self, subnet, ip_leases=None, mac_leases=None):
+		if not ip_leases:
+			ip_leases = {}
+		if not mac_leases:
+			mac_leases = {}
+
+		self.subnet = subnet
+		self.leases_by_mac = mac_leases
+		self.leases_by_ip = ip_leases
+
+	def lease(self, ip, mac):
+		self.leases_by_ip[str(ip)] = mac
+		self.leases_by_mac[mac] = str(ip)
+
+	def release(self, address):
+		try:
+			ip = ipaddress.ip_address(address)
+			mac = self.leases_by_ip.get(ip)
+		except ValueError:
+			if type(address) == bytes:
+				address = bytes_to_mac(address)
+
+			mac = address
+			ip = self.leases_by_mac.get(mac)
+		
+		if mac and ip:
+			del(self.leases_by_ip[ip])
+			del(self.leases_by_mac[mac])
+
+	def save(self, path):
+		with open(path, 'w') as output:
+			output.write(json.dumps({
+				'leases_by_ip' : self.leases_by_ip,
+				'leases_by_mac' : self.leases_by_mac
+			}))
+
+	def load(self, path):
+		if os.path.isfile((path := os.path.abspath(path))):
+			with open(path, 'r') as fh:
+				data = json.load(fh)
+				self.leases_by_mac = data['leases_by_mac']
+				self.leases_by_ip = data['leases_by_ip']
+
+	@property
+	def available_ip(self):
+		for host in self.subnet.hosts():
+			print(str(host), self.leases_by_ip)
+			if not str(host) in self.leases_by_ip:
+				return host
+
 class dhcp_serve():
-	def __init__(self, *args, **kwargs):
+	def __init__(self, lease_db, *args, **kwargs):
 		if not 'interface' in kwargs:
 			raise KeyError('dhcp_server() requires at least a interface=X to be given.')
 
-		## Cache variables:
-		self.leases_by_mac = {}
-		self.leases_by_ip = {}
+		if not kwargs.get('subnet'):
+			raise KeyError(f"dhcp_server() requires a valid subnet to be given: {kwargs['subnet']}")
 
 		## Update our self.variable = value references.
 		for var, val in kwargs.items():
 			self.__dict__[var] = val
 
+		self.lease_db = lease_db
+
 		with open(f'/sys/class/net/{self.interface}/address', 'r') as fh:
 			self.mac = fh.read().strip()
 
-		if self.is_gateway and self.mac not in self.leases_by_mac and self.gateway not in self.leases_by_ip:
+		if self.is_gateway and self.mac not in self.lease_db.leases_by_mac and self.gateway not in self.lease_db.leases_by_ip:
 			print(f'[-] We are the gateway: {{"gateway" : "{self.gateway}", "mac" : "{self.mac}"}}')
-			self.leases_by_ip[self.gateway] = self.mac
-			self.leases_by_mac[self.mac] = self.gateway
+			self.lease_db.leases_by_ip[self.gateway] = self.mac
+			self.lease_db.leases_by_mac[self.mac] = self.gateway
 		else:
 			print(f'[-] Gateway MAC unknown: {{"gateway" : "{self.gateway}", "mac" : "unknown"}}')
-			self.leases_by_ip[self.gateway] = '00:00:00:00:00:00'
-			self.leases_by_mac['00:00:00:00:00:00'] = self.gateway
+			self.lease_db.leases_by_ip[self.gateway] = '00:00:00:00:00:00'
+			self.lease_db.leases_by_mac['00:00:00:00:00:00'] = self.gateway
+
+		print(f"Initiated the server with leases: {self.lease_db.leases_by_mac} and {self.lease_db.leases_by_ip}")
 		
 		# https://github.com/Torxed/python-socket/blob/main/pysocket/pysocket.py
 		self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(ETH_P_ALL))
@@ -583,12 +713,10 @@ class dhcp_serve():
 		promisciousMode.on()
 
 		self.main_so_id = self.socket.fileno()
-		print(f'[-] Bound to: {{"interface" : "{kwargs["interface"]}", "address" : "255.255.255.255", "port" : 67}}')
+		print(f'[-] Bound to: {{"interface" : "{kwargs["interface"]}", "address" : "{kwargs["bind_to"]}", "port" : 67}}')
 
 		self.pollobj = epoll()
 		self.pollobj.register(self.main_so_id, EPOLLIN)
-
-		self.temp = []
 
 
 	def poll(self, timeout=0.001, fileno=None):
@@ -601,15 +729,15 @@ class dhcp_serve():
 		self.socket.close()
 
 	def get_lease(self, mac):
-		if mac in self.leases_by_mac:
-			return self.leases_by_mac[mac]
+		if mac in self.lease_db.leases_by_mac:
+			return self.lease_db.leases_by_mac[mac]
 		else:
 			return None
 
 	def parse(self):
 		# The struct just maps how many bytes (not bits) per section in a DHCP request.
 		# A graphic overview can be found here: https://tools.ietf.org/html/rfc2131#section-2
-		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4, 3]
+		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4]
 		# We then use that struct map to place the values into a dictionary with these keys (in order):
 		dhcp_protocol = ['msg type', 'hw type', 'hw addr len', 'hops',
 						 'transaction id',
@@ -623,12 +751,12 @@ class dhcp_serve():
 						 'server hostname',
 						 'boot file',
 						 'magic cookie',
-						 'option 53', # This is dangerous to assume
-						 'other']
+						 #'option 53', # This is dangerous to assume
+						 'options']
 
 		if self.poll():
 			data, auxillary_data_raw, flags, addr = self.socket.recvmsg(65535, socket.CMSG_LEN(4096))
-			
+
 			if not data:
 				return
 
@@ -643,7 +771,7 @@ class dhcp_serve():
 			mac_source = b':'.join(mac_source[i:i+2] for i in range(0, len(mac_source), 2))
 			mac_dest = b':'.join(mac_dest[i:i+2] for i in range(0, len(mac_dest), 2))
 			frame_type = binascii.hexlify(ethernet_segments[2])
-			
+
 			ip = data[14:34]
 			ip_segments = struct.unpack("!12s4s4s", ip)
 
@@ -684,35 +812,49 @@ class dhcp_serve():
 				request[dhcp_protocol[index]] = {'binary' : binary[index], 'bytes' : bin_str_to_byte(binary[index]), 'hex' : None}
 				request[dhcp_protocol[index]]['hex'] = bytes_to_hex(request[dhcp_protocol[index]]['bytes'])
 
-			print(f'[+] Packet from: {{"mac": "{human_mac(request["client mac"]["bytes"])}"}}')
+			print(f'[+] Request from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
+			if str(bytes_to_ip(request['relay agent']['bytes'])) != addr[0]:
+				if self.valid_relays.get(addr[0]) != str(bytes_to_ip(request['relay agent']['bytes'])):
+					print(f"[!] Inconsistency in relayed message, sender is not the same as the relay IP: Sender={addr[0]}, Relay-Agent={bytes_to_ip(request['relay agent']['bytes'])} ")
+					return None
+			print(f"[ ]  Relay via {bytes_to_ip(request['relay agent']['bytes'])}")
 
 			## Check if we've white listed clients,
 			## and if so, check if this client isn't allowed and return nothing on the cable.
 			if 'filter_clients' in args and args['filter_clients']:
-				if not human_mac(request["client mac"]["bytes"]) in args['filter_clients']:
-					print(f'[ ] Request ignored: {{"mac": "{human_mac(request["client mac"]["bytes"])}"}}')
+				if not bytes_to_mac(request["client mac"]["bytes"]) in args['filter_clients']:
+					print(f'[ ] Request ignored: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
 					return
 
-			## Extract the DHCP options from the client
-			requests_dhcp_options = request['other']['binary']
-			num_of_dhcp_options = ord(bin_str_to_byte([requests_dhcp_options[1]]))
+			# Build the remaining DHCP options by checking type, length and structuring data.
+			pos = 0
 			request['dhcp_options'] = {}
-			for item in range(num_of_dhcp_options):
-				request['dhcp_options'][item] = { 'binary' : requests_dhcp_options[item],
-												  'bytes' : bin_str_to_byte([requests_dhcp_options[item]])}
+			while pos < len(data) and pos <= 312:
+				option = request['options']['bytes'][pos]
+				if option == 255: # End
+					break
+				length = request['options']['bytes'][pos+1]
+				if pos + 2 + length > len(data):
+					# out of bounds check
+					break
+				data = request['options']['bytes'][pos+2:pos+2+length]
+				pos += 2 + length
+
+				request['dhcp_options'][f"option {option}"] = { 'binary' : None,
+																'bytes' : data}
 
 			## Got all the parsing and processing done.
 			## Time ot build a response if the requested packet was DHCP request of some kind.
 			packet = b''
 			if request['msg type']['bytes'][-1] == 1: # Message type: Boot request (1)
-				if request['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[ ] DHCP Discover from: {{"mac": "{human_mac(request["client mac"]["bytes"])}", "type" : "DHCP_DISCOVER"}}')
-				if request['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[ ] DHCP Request for IP from: {{"mac": "{human_mac(request["client mac"]["bytes"])}", "ip" : "<ignored>", "type" : "DHCP_REQUEST"}}')
+				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
+					print(f'[ ] DHCP Discover from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "type" : "DHCP_DISCOVER"}}')
+				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
+					print(f'[ ] DHCP Request for IP from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "ip" : "<ignored>", "type" : "DHCP_REQUEST"}}')
 
 				## Check lease time for the specific mac
 				## If we don't find a lease, begin the "generate new IP process".
-				mac = human_mac(request["client mac"]["bytes"])
+				mac = bytes_to_mac(request["client mac"]["bytes"])
 				if not (leased_ip := self.get_lease(mac)):
 					# The mac is filtered, and contains a static IP lease definition
 					if args['filter_clients'] and mac in args['filter_clients'] and args['filter_clients'][mac].count('.'):
@@ -720,12 +862,13 @@ class dhcp_serve():
 						print(f'[ ] Staticly giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "STATIC_DHCP_OFFER"}}')
 					# Otherwise, generate a IP from the total pool of available IP's
 					else:
-						leased_ip = gen_ip(self.subnet, self.leases_by_ip)
+						leased_ip = self.lease_db.available_ip
 						print(f'[ ] Dynamically giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "DYNAMIC_DHCP_OFFER"}}')
 					
 					if leased_ip:
-						self.leases_by_mac[mac] = leased_ip
-						self.leases_by_ip[leased_ip] = mac
+						self.lease_db.lease(leased_ip, mac)
+						#self.lease_db.leases_by_mac[mac] = leased_ip
+						#self.lease_db.leases_by_ip[leased_ip] = mac
 					else:
 						raise ValueError('TODO: Out of IP addresses..') # TODO: make a clean "continue" / "check if old leases expired"
 				# There was a pre-existing lease, using that lease:
@@ -742,14 +885,14 @@ class dhcp_serve():
 				packet += dhcp_option.dhcp_offer()
 				packet += dhcp_option.hardware_type('ethernet')
 				packet += dhcp_option.hardware_address_length(6)
-				packet += dhcp_option.hops(0)
+				packet += dhcp_option.hops(request['hops']['bytes'][0]+1)
 				packet += dhcp_option.trasnaction_id(request)
 				packet += dhcp_option.seconds_elapsed(0)
-				packet += dhcp_option.bootp_flags()
-				packet += dhcp_option.client_ip(request)
+				packet += dhcp_option.bootp_flags(request)
+				packet += dhcp_option.client_ip(request, self)
 				packet += dhcp_option.offered_ip(leased_ip)
 				packet += dhcp_option.next_server(self.pxe_server) # 0.0.0.0 == None
-				packet += dhcp_option.relay_agent(ipaddress.ip_address('0.0.0.0'))
+				packet += dhcp_option.relay_agent(bytes_to_ip(request['relay agent']['bytes']))
 				packet += dhcp_option.client_mac(request)
 				packet += dhcp_option.client_addr_padding()
 				packet += dhcp_option.server_host_name(request)
@@ -758,16 +901,16 @@ class dhcp_serve():
 
 				## This is basically what differs in a basic basic DHCP sequence,
 				## the message type recieved and matching response. At least for a basic IP request/handshake.
-				if request['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.leases_by_mac[mac]}"}}')
+				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
+					print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
 					packet += dhcp_option.TYPE('OFFER')
-				if request['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.leases_by_mac[mac]}"}}')
+				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
+					print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
 					packet += dhcp_option.TYPE('ACK')
 				
 				# Slap on the clients trasnacation identifier so it knows
 				# we responded to the request and not some other request it made.	
-				packet += dhcp_option.identifier(self.gateway)
+				packet += dhcp_option.identifier(self.bind_to)
 				
 				# We don't honor these, so we're generous with them:
 				packet += dhcp_option.lease_time(43200)
@@ -790,17 +933,35 @@ class dhcp_serve():
 				packet += b'\xff'   #End Option
 
 			if len(packet) > 0:
-				import array
-				socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(ETH_P_ALL)
-				print(auxillary_data_raw, auxillary_data)
-				self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)
+				# If the 'giaddr' field in a DHCP message from a client is non-zero,
+				# the server sends any return messages to the 'DHCP server' port on the
+				# BOOTP relay agent whose address appears in 'giaddr'. If the 'giaddr'
+				# field is zero and the 'ciaddr' field is nonzero, then the server
+				# unicasts DHCPOFFER and DHCPACK messages to the address in 'ciaddr'.
+				# If 'giaddr' is zero and 'ciaddr' is zero, and the broadcast bit is
+				# set, then the server broadcasts DHCPOFFER and DHCPACK messages to
+				# 0xffffffff. If the broadcast bit is not set and 'giaddr' is zero and
+				# 'ciaddr' is zero, then the server unicasts DHCPOFFER and DHCPACK
+				# messages to the client's hardware address and 'yiaddr' address.  In
+				# all cases, when 'giaddr' is zero, the server broadcasts any DHCPNAK
+				# messages to 0xffffffff.
+				if self.bind_to == '255.255.255.255':
+					print(f"[-] Broadcasting back response")
+					self.socket.sendmsg([packet], auxillary_data_raw, flags, ('255.255.255.255', 68))
+				else:
+					print(f"[-] Sending directly to {addr}")
+					self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)
 
 				if self.cache_db:
-					save_local_storage(self.cache_dir + '/' + self.cache_db, {**self.__dict__, 'socket' : None, 'pollobj' : None})
+					self.lease_db.save(self.cache_dir + '/' + self.cache_db)
+					#save_local_storage(self.cache_dir + '/' + self.cache_db, self.lease_db)
 
 if __name__ == '__main__':
+	instances = []
+
 	def sig_handler(signal, frame):
-		dhcp.close()
+		for instance in instances:
+			instance.close()
 		exit(0)
 	signal.signal(signal.SIGINT, sig_handler)
 
@@ -825,7 +986,7 @@ if __name__ == '__main__':
 		print('Usage: ')
 		print(' --interface=eth0          (mandatory)')
 		print(' --subnet=192.168.1.0/24   (default)')
-		print(' --gateway=192.168.1.1     (default)')
+		print(' --gateway=192.168.1.1     (default is the first ip on --interface)')
 		print(' --pxe_bin=ipxe.efi')
 		print(' --pxe_dir=/srv/pxe/')
 		print(' --filter_clients=\'{"de:ad:be:ef:00:01" : true, "de:ad:be:ef:00:02" : "192.168.1.10"}\'')
@@ -833,9 +994,7 @@ if __name__ == '__main__':
 	
 	if not 'cache_dir' in args: args['cache_dir'] = './'
 	if not 'cache_db' in args: args['cache_db'] = None
-	args = {**load_local_storage(f"{args['cache_dir']}/{args['cache_db']}"), **args}
-
-	if not 'subnet' in args: args['subnet'] = '192.168.1.0'
+	if not 'subnet' in args: args['subnet'] = None
 	if not 'netmask' in args: args['netmask'] = '255.255.255.0' # Optional, if it's given on the subnet definition.
 	if not 'gateway' in args: args['gateway'] = None # Takes the first host of the subnet by default
 	if not 'is_gateway' in args: args['is_gateway'] = False
@@ -843,13 +1002,28 @@ if __name__ == '__main__':
 	if not 'pxe_bin' in args: args['pxe_bin'] = None # Point toward a efi file, for instance: '/ipxe.efi'
 	if not 'pxe_dir' in args: args['pxe_dir'] = './'# './pxe_files'
 	if not 'pxe_config' in args: args['pxe_config'] = 'loader/loader.conf'
-	if not 'pxe_server' in args:
-		if args['pxe_bin']:
-			args['pxe_server'] = args['gateway']
-		else:
-			args['pxe_server'] = '0.0.0.0'
+	if not 'multi_bind' in args: args['multi_bind'] = True
+	if not 'valid_relays' in args: args['valid_relays'] = '{}'
+	if not 'pxe_server' in args: args['pxe_server'] = '0.0.0.0'
 	if not 'filter_clients' in args: args['filter_clients'] = '{}' # JSON structure of clients
+	args['valid_relays'] = json.loads(args['valid_relays'])
 
+	if not args['gateway'] and args['is_gateway']:
+		args['gateway'] = get_ip_address(args['interface'])
+		if not args['gateway']:
+			raise ValueError(f"slimDHCP could not detect a valid IP address on {args['interface']}, and --is_gateway was given, which requires us to be able to recieve traffic. This in turn means we can't guess a subnet to use.")
+	if args['multi_bind'] and get_ip_address(args['interface']) is None:
+		raise ValueError(f"slimDHCP was asked to bind to multiple IP's, however the interface doesn't have an IP which means we can only listen to broadcast traffic. Either do not attempt --multi_bind or assign a valid IP to the --interface {args['interface']}")
+
+	if not args['subnet'] and not args['gateway']:
+		args['subnet'] = '192.168.1.0'
+	elif not args['subnet']:
+		ip_information = get_network_interfaces().get(args['interface'], {})
+		first_available_ip = list(ip_information.keys())[0]
+		matching_subnet_mask = ip_information[first_available_ip]
+		args['subnet'] = str(ipaddress.ip_network(f"{first_available_ip}/{matching_subnet_mask}", strict=False).network_address)
+		if args['netmask'] != matching_subnet_mask:
+			raise ValueError(f"A subnet was autodetected as {args['subnet']}, but the autodetected netmask of {matching_subnet_mask} does not match the user specified --netmask.")
 
 	## Convert arguments to workable elements:
 	if type(args['dns_servers']) == str:
@@ -870,7 +1044,15 @@ if __name__ == '__main__':
 			args['gateway'] = host
 			break
 
-	dhcp = dhcp_serve(**args)
+	lease_database = Leases(args['subnet'])
+	if args['cache_dir'] and args['cache_db']:
+		lease_database.load(f"{args['cache_dir']}/{args['cache_db']}")
+
+	if args['multi_bind']:
+		instances.append(dhcp_serve(lease_db=lease_database, bind_to=get_ip_address(args['interface']), **{**args, 'gateway' : get_ip_address(args['interface'])}))
+	instances.append(dhcp_serve(lease_db=lease_database, bind_to='255.255.255.255', **args))
+
 	while 1:
-		if dhcp.poll():
-			dhcp.parse()
+		for instance in instances:
+			if instance.poll():
+				instance.parse()

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -1,16 +1,25 @@
 
 # https://www.netmanias.com/en/post/techdocs/6000/dhcp-network-protocol/understanding-dhcp-relay-agents
 
-import sys, struct, json, abc, os, copy, signal, ipaddress
+import sys, struct, json, abc, os, copy, signal
 import socket, fcntl
 from select import epoll, EPOLLIN
-from ctypes import (
-	Structure, Union, POINTER, 
-	pointer, get_errno, cast,
-	c_ushort, c_byte, c_void_p, c_char_p, c_uint, c_int, c_uint16, c_uint32
-)
+#from ctypes import (
+#	Structure, Union, POINTER, 
+#	pointer, get_errno, cast,
+#	c_ushort, c_byte, c_void_p, c_char_p, c_uint, c_int, c_uint16, c_uint32
+#)
 import ctypes.util
 import ctypes
+import pydantic
+import ipaddress
+import argparse
+import urllib.parse
+import urllib.request
+import pathlib
+import binascii
+import logging
+from typing import Optional, Dict, Union, List, Tuple, Any, Type
 
 # Static values to subscribe to aux data on individual packets
 ETH_P_ALL = 0x0003
@@ -74,31 +83,31 @@ class JSON_Typer(json.JSONEncoder):
 	def encode(self, obj):
 		return super(JSON_Typer, self).encode(self._encode(obj))
 
-class struct_sockaddr(Structure):
+class struct_sockaddr(ctypes.Structure):
 	 _fields_ = [
-		('sa_family', c_ushort),
-		('sa_data', c_byte * 14),]
+		('sa_family', ctypes.c_ushort),
+		('sa_data', ctypes.c_byte * 14),]
 
-class struct_sockaddr_in(Structure):
+class struct_sockaddr_in(ctypes.Structure):
 	_fields_ = [
-		('sin_family', c_ushort),
-		('sin_port', c_uint16),
-		('sin_addr', c_byte * 4)]
+		('sin_family', ctypes.c_ushort),
+		('sin_port', ctypes.c_uint16),
+		('sin_addr', ctypes.c_byte * 4)]
 
-class struct_sockaddr_in6(Structure):
+class struct_sockaddr_in6(ctypes.Structure):
 	_fields_ = [
-		('sin6_family', c_ushort),
-		('sin6_port', c_uint16),
-		('sin6_flowinfo', c_uint32),
-		('sin6_addr', c_byte * 16),
-		('sin6_scope_id', c_uint32)]
+		('sin6_family', ctypes.c_ushort),
+		('sin6_port', ctypes.c_uint16),
+		('sin6_flowinfo', ctypes.c_uint32),
+		('sin6_addr', ctypes.c_byte * 16),
+		('sin6_scope_id', ctypes.c_uint32)]
 
-class union_ifa_ifu(Union):
+class union_ifa_ifu(ctypes.Union):
 	_fields_ = [
-		('ifu_broadaddr', POINTER(struct_sockaddr)),
-		('ifu_dstaddr', POINTER(struct_sockaddr)),]
+		('ifu_broadaddr', ctypes.POINTER(struct_sockaddr)),
+		('ifu_dstaddr', ctypes.POINTER(struct_sockaddr)),]
 
-class struct_ifaddrs(Structure):
+class struct_ifaddrs(ctypes.Structure):
 	pass
 
 def ifap_iter(ifap):
@@ -113,10 +122,10 @@ def getfamaddr(sa):
 	family = sa.sa_family
 	addr = None
 	if family == socket.AF_INET:
-		sa = cast(pointer(sa), POINTER(struct_sockaddr_in)).contents
+		sa = ctypes.cast(ctypes.pointer(sa), ctypes.POINTER(struct_sockaddr_in)).contents
 		addr = socket.inet_ntop(family, sa.sin_addr)
 	elif family == socket.AF_INET6:
-		sa = cast(pointer(sa), POINTER(struct_sockaddr_in6)).contents
+		sa = ctypes.cast(ctypes.pointer(sa), ctypes.POINTER(struct_sockaddr_in6)).contents
 		addr = socket.inet_ntop(family, sa.sin6_addr)
 	return family, addr
 
@@ -133,8 +142,8 @@ class NetworkInterface(object):
 			self.addresses.get(socket.AF_INET6))
 
 def get_network_interfaces():
-	ifap = POINTER(struct_ifaddrs)()
-	result = libc.getifaddrs(pointer(ifap))
+	ifap = ctypes.POINTER(struct_ifaddrs)()
+	result = libc.getifaddrs(ctypes.pointer(ifap))
 	if result != 0:
 		raise OSError(get_errno())
 	del result
@@ -144,6 +153,7 @@ def get_network_interfaces():
 			name = ifa.ifa_name
 			if not name.decode('UTF-8') in retval:
 				retval[name.decode('UTF-8')] = {}
+			
 			try:
 				family, addr = getfamaddr(ifa.ifa_addr.contents)
 				family, subnet = getfamaddr(ifa.ifa_netmask.contents)
@@ -151,21 +161,119 @@ def get_network_interfaces():
 				family, addr, subnet = None, None, None
 
 			if addr:
-				retval[name.decode('UTF-8')][addr] = subnet
+				# TODO: Does not support IPv6.
+				# the addr is/can be IPv6, but the ipaddress.ip_network() fails
+				try:
+					retval[name.decode('UTF-8')][ipaddress.ip_address(addr)] = ipaddress.ip_network(f"{ipaddress.ip_address(addr)}/{subnet}", strict=False)
+				except ValueError:
+					pass
 		return retval
 	finally:
 		libc.freeifaddrs(ifap)
 
 struct_ifaddrs._fields_ = [
-	('ifa_next', POINTER(struct_ifaddrs)),
-	('ifa_name', c_char_p),
-	('ifa_flags', c_uint),
-	('ifa_addr', POINTER(struct_sockaddr)),
-	('ifa_netmask', POINTER(struct_sockaddr)),
+	('ifa_next', ctypes.POINTER(struct_ifaddrs)),
+	('ifa_name', ctypes.c_char_p),
+	('ifa_flags', ctypes.c_uint),
+	('ifa_addr', ctypes.POINTER(struct_sockaddr)),
+	('ifa_netmask', ctypes.POINTER(struct_sockaddr)),
 	('ifa_ifu', union_ifa_ifu),
-	('ifa_data', c_void_p),]
+	('ifa_data', ctypes.c_void_p),]
 
 libc = ctypes.CDLL(ctypes.util.find_library('c'))
+
+
+class Journald:
+	@staticmethod
+	def log(message :str, level :int = logging.DEBUG) -> None:
+		try:
+			import systemd.journal  # type: ignore
+		except ModuleNotFoundError:
+			return None
+
+		log_adapter = logging.getLogger('archinstall')
+		log_fmt = logging.Formatter("[%(levelname)s]: %(message)s")
+		log_ch = systemd.journal.JournalHandler()
+		log_ch.setFormatter(log_fmt)
+		log_adapter.addHandler(log_ch)
+		log_adapter.setLevel(logging.DEBUG)
+
+		log_adapter.log(level, message)
+
+def supports_color() -> bool:
+	"""
+	Return True if the running system's terminal supports color,
+	and False otherwise.
+	"""
+	supported_platform = sys.platform != 'win32' or 'ANSICON' in os.environ
+
+	# isatty is not always implemented, #6223.
+	is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+	return supported_platform and is_a_tty
+
+# Heavily influenced by: https://github.com/django/django/blob/ae8338daf34fd746771e0678081999b656177bae/django/utils/termcolors.py#L13
+# Color options here: https://askubuntu.com/questions/528928/how-to-do-underline-bold-italic-strikethrough-color-background-and-size-i
+def stylize_output(text: str, *opts :str, **kwargs) -> str:
+	"""
+	Adds styling to a text given a set of color arguments.
+	"""
+	opt_dict = {'bold': '1', 'italic': '3', 'underscore': '4', 'blink': '5', 'reverse': '7', 'conceal': '8'}
+	colors = {
+		'black' : '0',
+		'red' : '1',
+		'green' : '2',
+		'yellow' : '3',
+		'blue' : '4',
+		'magenta' : '5',
+		'cyan' : '6',
+		'white' : '7',
+		'orange' : '8;5;208',    # Extended 256-bit colors (not always supported)
+		'darkorange' : '8;5;202',# https://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#256-colors
+		'gray' : '8;5;246',
+		'darkgray' : '8;5;240',
+		'lightgray' : '8;5;256'
+	}
+	foreground = {key: f'3{colors[key]}' for key in colors}
+	background = {key: f'4{colors[key]}' for key in colors}
+	reset = '0'
+
+	code_list = []
+	if text == '' and len(opts) == 1 and opts[0] == 'reset':
+		return '\x1b[%sm' % reset
+
+	for k, v in kwargs.items():
+		if k == 'fg':
+			code_list.append(foreground[str(v)])
+		elif k == 'bg':
+			code_list.append(background[str(v)])
+
+	for o in opts:
+		if o in opt_dict:
+			code_list.append(opt_dict[o])
+
+	if 'noreset' not in opts:
+		text = '%s\x1b[%sm' % (text or '', reset)
+
+	return '%s%s' % (('\x1b[%sm' % ';'.join(code_list)), text or '')
+
+
+def log(*args :str, **kwargs :Union[str, int, Dict[str, Union[str, int]]]) -> None:
+	string = orig_string = ' '.join([str(x) for x in args])
+
+	# Attempt to colorize the output if supported
+	# Insert default colors and override with **kwargs
+	if supports_color():
+		kwargs = {'fg': 'white', **kwargs}
+		string = stylize_output(string, **kwargs)
+
+	Journald.log(string, level=int(str(kwargs.get('level', logging.INFO))))
+
+	# Finally, print the log unless we skipped it based on level.
+	# We use sys.stdout.write()+flush() instead of print() to try and
+	# fix issue #94
+	if kwargs.get('level', logging.INFO) != logging.DEBUG or storage['arguments'].get('verbose', False):
+		sys.stdout.write(f"{string}\n")
+		sys.stdout.flush()
 
 def get_ip_address(ifname):
 	if not type(ifname) == bytes:
@@ -173,13 +281,17 @@ def get_ip_address(ifname):
 	s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 	try:
-		return socket.inet_ntoa(fcntl.ioctl(
-			s.fileno(),
-			0x8915,  # SIOCGIFADDR
-			struct.pack('256s', ifname[:15])
-		)[20:24])
+		return ipaddress.IPv4Address(
+			socket.inet_ntoa(fcntl.ioctl(
+				s.fileno(),
+				0x8915,  # SIOCGIFADDR
+				struct.pack('256s', ifname[:15])
+			)[20:24])
+		)
 	except:
-		return None
+		pass
+
+	return None
 
 def byte_to_bin(bs, bin_map=None):
 	"""
@@ -194,18 +306,10 @@ def byte_to_bin(bs, bin_map=None):
 	TODO: handle bin_map = None
 	"""
 	raw = []
-	index = 0
-	for length in bin_map:
-		mipmap = []
-		for i in bs[index:index+length]:
-			mipmap.append('{0:b}'.format(i).zfill(8))
-		raw.append(mipmap)
-		index += length
-	if index < len(bs):
-		mipmap = []
-		for i in bs[index:]:
-			mipmap.append('{0:b}'.format(i).zfill(8))
-		raw.append(mipmap)
+
+	for i in bs:
+		raw.append('{0:b}'.format(i).zfill(8))
+
 	return raw
 
 def binToObj(b, func):
@@ -317,10 +421,12 @@ def parse_auxillary_data(auxillary_data):
 			}
 
 def mac_to_bytes(mac):
-	if not type(mac) == bytes:
-		raise ValueError("mac_to_bytes needs bytes as the mac address")
-	if not b':' in mac:
+	if type(mac) != bytes:
+		mac = bytes(mac, 'UTF-8')
+	
+	if b':' not in mac:
 		raise ValueError("mac_to_bytes needs : separated mac addresses")
+
 	return b''.join([struct.pack('B', int(mac_part, 16)) for mac_part in mac.split(b':')])
 
 def ethernet(src, dst):
@@ -380,8 +486,13 @@ class ifreq(ctypes.Structure):
 					("ifr_flags", ctypes.c_short)]
 
 class promisc():
+	IFF_PROMISC = 0x100
+	SIOCGIFFLAGS = 0x8913
+	SIOCSIFFLAGS = 0x8914
+
 	def __init__(self, s, interface=b'ens33'):
 		self.s = s
+		self.fileno = s.fileno()
 		self.interface = interface
 		self.ifr = ifreq()
 
@@ -389,25 +500,22 @@ class promisc():
 		## -- Set up promisc mode:
 		## 
 
-		IFF_PROMISC = 0x100
-		SIOCGIFFLAGS = 0x8913
-		SIOCSIFFLAGS = 0x8914
 
 		self.ifr.ifr_ifrn = self.interface
 
-		fcntl.ioctl(self.s.fileno(), SIOCGIFFLAGS, self.ifr)
-		self.ifr.ifr_flags |= IFF_PROMISC
+		fcntl.ioctl(self.fileno, self.SIOCGIFFLAGS, self.ifr)
+		self.ifr.ifr_flags |= self.IFF_PROMISC
 
-		fcntl.ioctl(self.s.fileno(), SIOCSIFFLAGS, self.ifr)
+		fcntl.ioctl(self.fileno, self.SIOCSIFFLAGS, self.ifr)
 		## ------------- DONE
 
 	def off(self):
 		## Turn promisc mode off:
-		self.ifr.ifr_flags &= ~IFF_PROMISC
-		fcntl.ioctl(self.s.fileno(), SIOCSIFFLAGS, self.ifr)
+		self.ifr.ifr_flags &= ~self.IFF_PROMISC
+		fcntl.ioctl(self.fileno, self.SIOCSIFFLAGS, self.ifr)
 		## ------------- DONE
 
-class dhcp_option(abc.ABCMeta):
+class dhcp_fields(abc.ABCMeta):
 	"""
 	This class abstracts the build process of using struct.pack() to
 	create a structure that looks like: option | length | data
@@ -466,52 +574,43 @@ class dhcp_option(abc.ABCMeta):
 		return b'\x06'
 
 	@abc.abstractmethod
-	def trasnaction_id(request):
-		return request['transaction id']['bytes']
+	def transaction_id(identifier :int):
+		return struct.pack('>I', identifier)
 
 	@abc.abstractmethod
 	def seconds_elapsed(t=0):
 		return struct.pack('>H', t)
 
 	@abc.abstractmethod
-	def bootp_flags(request):
-		# https://www.ietf.org/rfc/rfc2131.txt
-		# page 10:
-		#
-		# To work around some clients that cannot accept IP unicast datagrams
-		# before the TCP/IP software is configured ...
-		# [Unicast must not be used]
-		if not int(bin(request['bootp flags']['bytes'][0])[2:][0]):
-			return b'\x00\x00'
-		else:
-			return b'\x80\x00'
+	def bootp_flags(flags :bytes):
+		return flags
 
 	@abc.abstractmethod
-	def client_ip(request, server_instance): # 0.0.0.0 (We could honor it, but that's a TODO)
-		if request['client ip']['bytes'] != b'\x00\x00\x00\x00':
-			print('Client is asking for IP:', [bytes_to_ip(request['client ip']['bytes'])], 'in leases', server_instance.leases_by_ip)
-			if (ip := bytes_to_ip(request['client ip']['bytes'])) in server_instance.leases_by_ip:
-				print('IP was in leases')
-				if (mac := bytes_to_mac(request['client mac']['bytes'])) in server_instance.leases_by_mac:
-					print(f"IP {ip} and MAC {mac} was identified as a previous lease: {server_instance.leases_by_mac[mac]}")
-					#if ip == server_instance.leases_by_mac[mac]:
+	def client_ip(client_ip :ipaddress.IPv4Address): # TODO: We won't honor any requested
+		#if request['client ip']['bytes'] != b'\x00\x00\x00\x00':
+		#	print('Client is asking for IP:', [bytes_to_ip(request['client ip']['bytes'])], 'in leases', server_instance.leases_by_ip)
+		#	if (ip := bytes_to_ip(request['client ip']['bytes'])) in server_instance.leases_by_ip:
+		#		print('IP was in leases')
+		#		if (mac := bytes_to_mac(request['client mac']['bytes'])) in server_instance.leases_by_mac:
+		#			print(f"IP {ip} and MAC {mac} was identified as a previous lease: {server_instance.leases_by_mac[mac]}")
+		#			#if ip == server_instance.leases_by_mac[mac]:
 		return b'\x00\x00\x00\x00'
 
 	@abc.abstractmethod
 	def offered_ip(addr):
-		return ip_to_bytes(addr)
+		return ip_to_bytes(str(addr))
 
 	@abc.abstractmethod
 	def next_server(addr):
-		return ip_to_bytes(addr)
+		return ip_to_bytes(str(addr))
 
 	@abc.abstractmethod
 	def relay_agent(addr='0.0.0.0'):
-		return ip_to_bytes(addr) # Relay agent IP address: 0.0.0.0 because I have no idea what this is heh
+		return ip_to_bytes(str(addr)) # Relay agent IP address: 0.0.0.0 because I have no idea what this is heh
 
 	@abc.abstractmethod
-	def client_mac(request):
-		return request['client mac']['bytes']
+	def client_mac(address):
+		return mac_to_bytes(address)
 
 	@abc.abstractmethod
 	def client_addr_padding():
@@ -627,427 +726,765 @@ class dhcp_option(abc.ABCMeta):
 		rt = struct.pack('>I', t)
 		return binInt(59)+struct.pack('B', len(rt))+rt # Rebinding Time Value
 
-class Leases():
-	def __init__(self, subnet, ip_leases=None, mac_leases=None):
-		if not ip_leases:
-			ip_leases = {}
-		if not mac_leases:
-			mac_leases = {}
+class NonIPv4Frame(BaseException):
+	pass
+class NonBroadcastFrame(BaseException):
+	pass
+class NonDHCPFrame(BaseException):
+	pass
+class InvalidFrameLength(BaseException):
+	pass
 
-		self.subnet = subnet
-		self.leases_by_mac = mac_leases
-		self.leases_by_ip = ip_leases
+class AuxillaryItem(pydantic.BaseModel):
+	status: Any
+	length: Any
+	snap_length: Any
+	mac: Any
+	net: Any
+	vlan: Any
+	padding: Any
 
-	def lease(self, ip, mac):
-		self.leases_by_ip[str(ip)] = mac
-		self.leases_by_mac[mac] = str(ip)
+# class AuxillaryList(pydantic.BaseModel):
+# 	items: List[AuxillaryItem] = []
 
-	def release(self, address):
-		try:
-			ip = ipaddress.ip_address(address)
-			mac = self.leases_by_ip.get(ip)
-		except ValueError:
-			if type(address) == bytes:
-				address = bytes_to_mac(address)
+# 	@pydantic.validator("*", pre=True)
+# 	def convert(cls, value):
+# 		print(value)
+# 		result = []
+# 		for message_level, message_type, message_data in auxillary_data:
+# 			if message_level == SOL_PACKET and message_type == PACKET_AUXDATA:
+# 				auxdata = tpacket_auxdata.from_buffer_copy(message_data)
+# 				result.append(
+# 					AuxillaryItem({
+# 						'status' : auxdata.tp_status,
+# 						'length' : auxdata.tp_len,
+# 						'snap_length' : auxdata.tp_snaplen,
+# 						'mac' : auxdata.tp_mac,
+# 						'net' : auxdata.tp_net,
+# 						'vlan' : auxdata.tp_vlan_tci,
+# 						'padding' : auxdata.tp_padding
+# 					})
+# 				)
+# 		return result
 
-			mac = address
-			ip = self.leases_by_mac.get(mac)
-		
-		if mac and ip:
-			del(self.leases_by_ip[ip])
-			del(self.leases_by_mac[mac])
+class Ethernet_IPv4:
+	pass
 
-	def save(self, path):
-		with open(path, 'w') as output:
-			output.write(json.dumps({
-				'leases_by_ip' : self.leases_by_ip,
-				'leases_by_mac' : self.leases_by_mac
-			}))
+class Ethernet_Unknown:
+	pass
 
-	def load(self, path):
-		if os.path.isfile((path := os.path.abspath(path))):
-			with open(path, 'r') as fh:
-				data = json.load(fh)
-				self.leases_by_mac = data['leases_by_mac']
-				self.leases_by_ip = data['leases_by_ip']
+class Ethernet(pydantic.BaseModel):
+	source: pydantic.constr(to_lower=True, min_length=17, max_length=17)
+	destination: pydantic.constr(to_lower=True, min_length=17, max_length=17)
+	payload_type: Union[Type[Ethernet_IPv4], Type[Ethernet_Unknown]]
+
+	class Config:
+		arbitrary_types_allowed = True
+		smart_union = True
+
+	@pydantic.validator("payload_type", pre=True)
+	def convert(cls, value):
+		# IPv4 == \x08\x00
+		if value == b'0800':
+			return Ethernet_IPv4
+		return Ethernet_Unknown
+
+class UDP(pydantic.BaseModel):
+	source_port: int
+	destination_port: int
+	length: int
+	checksum: Any
+
+class IPv4(pydantic.BaseModel):
+	source: ipaddress.IPv4Network
+	destination: ipaddress.IPv4Network
+	payload: UDP
+
+class DHCPBootRequest(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> 'DHCPBootRequest':
+		if (data := struct.unpack('B', data)[0]) == 1: # Boot request (1)
+			return cls
+
+	# Ignored
+	def __repr__(self):
+		return 'DHCPBootRequest'
+
+	# Ignored
+	def __str__(self):
+		return 'DHCPBootRequest'
+
+class HardwareType(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> 'HardwareType':
+		if (data := struct.unpack('B', data)[0]) == 1: # Ethernet
+			return Ethernet
+
+class ByteToInt(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> int:
+		return struct.unpack('B', data)[0]
+
+class BytesToInt(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> int:
+		return struct.unpack('i', data)[0]
+
+class BytesToShort(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> int:
+		return struct.unpack('h', data)[0]
+
+class BytesToIP(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> ipaddress.IPv4Address:
+		s = ''
+		for i in data:
+			s += '{:d}.'.format(i) # Int -> INT.
+		return ipaddress.ip_address(s[:-1])
+
+class BytesToMAC(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> str:
+		return ':'.join([item[2:].zfill(2) for item in binToObj(data, hex)])
+
+class BytesToUTF8String(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, data: bytes) -> str:
+		return data.strip(b'\x00').decode('UTF-8')
+
+class DHCPMessageType(pydantic.BaseModel):
+	data: int
+	binary: List[str]
+
+	@pydantic.validator("data", pre=True)
+	def validator(cls, value):
+		return struct.unpack('B', value)[0]
 
 	@property
-	def available_ip(self):
-		for host in self.subnet.hosts():
-			print(str(host), self.leases_by_ip)
-			if not str(host) in self.leases_by_ip:
-				return host
+	def discover(self):
+		if self.data == 1:
+			return True
 
-class dhcp_serve():
-	def __init__(self, lease_db, *args, **kwargs):
-		if not 'interface' in kwargs:
-			raise KeyError('dhcp_server() requires at least a interface=X to be given.')
+	@property
+	def offer(self):
+		if self.data == 2:
+			return True
 
-		if not kwargs.get('subnet'):
-			raise KeyError(f"dhcp_server() requires a valid subnet to be given: {kwargs['subnet']}")
+	@property
+	def request(self):
+		if self.data == 3:
+			return True
 
-		## Update our self.variable = value references.
-		for var, val in kwargs.items():
-			self.__dict__[var] = val
+	@property
+	def decline(self):
+		if self.data == 4:
+			return True
 
-		self.lease_db = lease_db
+	@property
+	def acknowledgement(self):
+		if self.data == 5:
+			return True
 
-		with open(f'/sys/class/net/{self.interface}/address', 'r') as fh:
-			self.mac = fh.read().strip()
+	@property
+	def negative_acknowledgement(self):
+		if self.data == 6:
+			return True
 
-		if self.is_gateway and self.mac not in self.lease_db.leases_by_mac and self.gateway not in self.lease_db.leases_by_ip:
-			print(f'[-] We are the gateway: {{"gateway" : "{self.gateway}", "mac" : "{self.mac}"}}')
-			self.lease_db.leases_by_ip[self.gateway] = self.mac
-			self.lease_db.leases_by_mac[self.mac] = self.gateway
-		else:
-			print(f'[-] Gateway MAC unknown: {{"gateway" : "{self.gateway}", "mac" : "unknown"}}')
-			self.lease_db.leases_by_ip[self.gateway] = '00:00:00:00:00:00'
-			self.lease_db.leases_by_mac['00:00:00:00:00:00'] = self.gateway
+	@property
+	def release(self):
+		if self.data == 7:
+			return True
 
-		print(f"Initiated the server with leases: {self.lease_db.leases_by_mac} and {self.lease_db.leases_by_ip}")
+	@property
+	def informational(self):
+		if self.data == 8:
+			return True
+
+class DHCPOPtions(pydantic.BaseModel):
+	""" 
+	<<<
+		1 = DHCP Discover message (DHCPDiscover).
+		2 = DHCP Offer message (DHCPOffer).
+		3 = DHCP Request message (DHCPRequest).
+		4 = DHCP Decline message (DHCPDecline).
+		5 = DHCP Acknowledgment message (DHCPAck).
+		6 = DHCP Negative Acknowledgment message (DHCPNak).
+		7 = DHCP Release message (DHCPRelease).
+		8 = DHCP Informational message (DHCPInform).
+	>>>
+	"""
+	option_53: DHCPMessageType
+
+	@pydantic.validator("*", pre=True)
+	def validator(cls, value):
+		return value
+
+class DHCPOptionsParser(bytes):
+	@classmethod
+	def __get_validators__(cls):
+		yield cls.validator
+	
+	@classmethod
+	def validator(cls, raw_data: bytes) -> DHCPOPtions:
+		# Build the remaining DHCP options by checking type, length and structuring data.
+		pos = 0
+		options = {}
+		while pos < len(raw_data) and pos <= 312:
+			option = raw_data[pos]
+			if option == 255: # End
+				break
+			length = raw_data[pos+1]
+			if pos + 2 + length > len(raw_data):
+				# out of bounds check
+				break
+			data = raw_data[pos+2:pos+2+length]
+			pos += 2 + length
+
+			options[f"option_{option}"] = {'binary' : byte_to_bin(data), 'data' : data}
+
+		return DHCPOPtions(**options)
+
+class DHCPRequest(pydantic.BaseModel):
+	message_type: Union[DHCPBootRequest]
+	hardware_type: HardwareType
+	hardware_addr_len: ByteToInt
+	hops: ByteToInt
+	transaction_id: BytesToInt
+	elapsed_time: BytesToShort
+	bootp_flags: bytes
+	client_ip: BytesToIP
+	client_assigned_ip: BytesToIP
+	server_ip: BytesToIP
+	relay_agent: BytesToIP
+	client_mac: BytesToMAC
+	#client_padding: bytes
+	server_hostname: BytesToUTF8String
+	boot_file: BytesToUTF8String
+	magic_cookie: bool
+	options: DHCPOptionsParser
+	raw_data: bytes
+
+	@pydantic.validator("magic_cookie", pre=True)
+	def magic_cookie_check(cls, data):
+		if data != b'c\x82Sc':
+			raise ValueError("Incorrect magic cookie")
+		return True
+
+	# @pydantic.validator("message_type", pre=True)
+	# def convert(cls, data):
+	# 	print(struct.unpack('B', data))
+	# 	if (message_type := struct.unpack('B', data)[0]) == 1: # Boot request (1)
+	# 		return type(DHCPRequestType())
+
+class Frame(pydantic.BaseModel):
+	server: 'DHCPServer'
+	request: DHCPRequest
+	auxillary_data: List[AuxillaryItem]
+	auxillary_data_raw: List[Tuple[int, int, bytes]]
+	flags: int
+	addr: Tuple[str, int, int, int, bytes]
+	processed: bool = False
+
+	class Config:
+		arbitrary_types_allowed = True
+
+	@pydantic.validator("request", pre=True)
+	def convert(cls, data):
+		if len(data) < 312 or len(data) > 65535:
+			raise InvalidFrameLength
+
+		if len(data) < 42:
+			# We need at least 42 bytes to grab the IP headers
+			raise InvalidFrameLength
+
+		if cls.ethernet(data).payload_type != Ethernet_IPv4:
+			raise NonIPv4Frame
 		
-		# https://github.com/Torxed/python-socket/blob/main/pysocket/pysocket.py
+		if cls.ethernet(data).destination != 'ff:ff:ff:ff:ff:ff':
+			# We only accept broadcasts
+			raise NonBroadcastFrame
+
+		if cls.ip(data).payload.destination_port != 67:
+			raise NonDHCPFrame
+
+		# The struct just maps how many bytes (not bits) per section in a DHCP request.
+		# A graphic overview can be found here: https://tools.ietf.org/html/rfc2131#section-2
+		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4, 312]
+
+		# We then use that struct map to place the values into a dictionary with these keys (in order):
+		dhcp_protocol = [
+			'message_type', 'hardware_type', 'hardware_addr_len', 'hops',
+			 'transaction_id',
+			 'elapsed_time', 'bootp_flags',
+			 'client_ip',
+			 'client_assigned_ip',
+			 'server_ip',
+			 'relay_agent',
+			 'client_mac',
+			 'client_padding',
+			 'server_hostname',
+			 'boot_file',
+			 'magic_cookie',
+			 'options'
+		]
+
+		binary = list(byte_to_bin(data[42:], bin_map=dhcp_packet_struct))
+
+		request = {}
+		for index, frame_section_length in enumerate(dhcp_packet_struct):
+			previous = sum(dhcp_packet_struct[:index])
+			binary_representation = binary[previous:previous+dhcp_packet_struct[index]]
+			bytes_string = bin_str_to_byte(binary_representation)
+
+			request[dhcp_protocol[index]] = {
+				'binary' : binary_representation,
+				'bytes' : bytes_string,
+				'hex' : bytes_to_hex(bytes_string)
+			}
+
+		#for index in range(len(binary)):
+		#	request[dhcp_protocol[index]] = {'binary' : binary[index], 'bytes' : bin_str_to_byte(binary[index]), 'hex' : None}
+		#	request[dhcp_protocol[index]]['hex'] = bytes_to_hex(request[dhcp_protocol[index]]['bytes'])
+
+		request = DHCPRequest(
+			**{
+				key: value['bytes'] for key, value in request.items() if key != 'client_padding'
+			},
+			raw_data=data
+		)
+
+		log(request, fg="yellow", level=logging.INFO)
+
+		return request
+
+	def response(self):
+		return FrameResponse(frame=self)
+
+	def ethernet(data):
+		ethernet_segments = struct.unpack("!6s6s2s", data[0:14])
+		mac_dest, mac_source = (binascii.hexlify(mac) for mac in ethernet_segments[:2])
+		return Ethernet(
+			source=':'.join(mac_source[i:i+2].decode('UTF-8') for i in range(0, len(mac_source), 2)),
+			destination=':'.join(mac_dest[i:i+2].decode('UTF-8') for i in range(0, len(mac_dest), 2)),
+			payload_type=binascii.hexlify(ethernet_segments[2])
+		)
+
+	@property
+	def Ethernet(self):
+		return Frame.ethernet(self.request.raw_data)
+
+	def ip(data):
+		ip_segments = struct.unpack("!12s4s4s", data[14:34])
+
+		ip_source, ip_dest = [
+			ipaddress.ip_address(x) for x in (
+				socket.inet_ntoa(section) for section in ip_segments[1:3]
+			)
+		]
+
+		source_port, destination_port, udp_payload_len, udp_checksum = struct.unpack("!hhh2s", data[34:42])
+
+		udp_payload = UDP(source_port=source_port, destination_port=destination_port, length=udp_payload_len, checksum=udp_checksum)
+		ip_frame = IPv4(source=ip_source, destination=ip_dest, payload=udp_payload)
+
+		return ip_frame
+
+	@property
+	def IPv4(self):
+		return Frame.ip(self.request.raw_data)
+
+class DHCPResponse(pydantic.BaseModel):
+	request_frame: Frame
+	data: bytes
+
+class FrameResponse(pydantic.BaseModel):
+	frame: DHCPResponse
+
+	@pydantic.validator("frame", pre=True)
+	def validator(cls, frame) -> DHCPResponse:
+		# Assemble the packet headers
+		packet = b''
+		packet += ethernet(src=frame.server.mac, dst=frame.Ethernet.source) + b'\x81\x00'
+		packet += struct.pack('>h', 0b0000000000000010) + struct.pack('H', frame.auxillary_data[0].vlan)# vlan(struct.pack('>h', 0b0000000000000010) + b'\x08\x00')
+		packet += ipv4(src='172.23.0.1', dst='255.255.255.255')
+		packet += udp(src=67, dst=68)
+
+
+		# Assemble the DHCP specific payload
+		packet += dhcp_fields.dhcp_offer()
+		packet += dhcp_fields.hardware_type('ethernet')
+		packet += dhcp_fields.hardware_address_length(6)
+		packet += dhcp_fields.hops(frame.request.hops)
+		packet += dhcp_fields.transaction_id(frame.request.transaction_id)
+		packet += dhcp_fields.seconds_elapsed(0)
+		# https://www.ietf.org/rfc/rfc2131.txt
+		# page 10:
+		#
+		# To work around some clients that cannot accept IP unicast datagrams
+		# before the TCP/IP software is configured ...
+		# [Unicast must not be used]
+		if not int(bin(frame.request.bootp_flags[0])[2:][0]):
+			packet += dhcp_fields.bootp_flags(b'\x00\x00')
+		else:
+			packet += dhcp_fields.bootp_flags(b'\x80\x00')
+		packet += dhcp_fields.client_ip(frame.request.client_ip)
+		packet += dhcp_fields.offered_ip('192.168.5.20')
+		if frame.server.configuration.dhcp.pxe:
+			packet += dhcp_fields.next_server(frame.server.configuration.dhcp.pxe.next_server)
+		else:
+			packet += dhcp_fields.next_server(ipaddress.ip_address('0.0.0.0'))
+		packet += dhcp_fields.relay_agent(frame.request.relay_agent)
+		packet += dhcp_fields.client_mac(frame.Ethernet.source)
+		packet += dhcp_fields.client_addr_padding()
+		packet += dhcp_fields.server_host_name(frame.request.server_hostname)
+		packet += b'\x00' * 128 # TODO: Unknown
+		packet += dhcp_fields.magic_cookie()
+
+		"""
+		## This is basically what differs in a basic basic DHCP sequence,
+		## the message type recieved and matching response. At least for a basic IP request/handshake.
+		if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
+			print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
+			packet += dhcp_fields.TYPE('OFFER')
+		if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
+			print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
+			packet += dhcp_fields.TYPE('ACK')
+		
+		# Slap on the clients trasnacation identifier so it knows
+		# we responded to the request and not some other request it made.	
+		packet += dhcp_fields.identifier(self.bind_to)
+		
+		# We don't honor these, so we're generous with them:
+		packet += dhcp_fields.lease_time(43200)
+		packet += dhcp_fields.renewal_time(21600)
+		packet += dhcp_fields.rebind_time(37800)
+
+		# And the IP, subnet, router(gateway) and DNS information.
+		packet += dhcp_fields.subnet(self.subnet.netmask)
+		packet += dhcp_fields.broadcast_addr(self.subnet.broadcast_address)
+		packet += dhcp_fields.router(self.gateway)
+		packet += dhcp_fields.dns_servers(*self.dns_servers)
+
+		# If we have a PXE binary to deliver, add the appropriate options to the request:
+		if self.pxe_bin:
+			packet += dhcp_fields.tftp_server_name(self.gateway)
+			packet += dhcp_fields.boot_file(self.pxe_bin)
+			packet += dhcp_fields.boot_file_prefix(self.pxe_dir)
+			packet += dhcp_fields.boot_file_configuration(self.pxe_config)
+
+		packet += b'\xff'   #End Option
+
+		"""
+		return DHCPResponse(request_frame=frame, data=packet)
+
+class DHCPServer:
+	def __init__(self, configuration, leases):
+		self.configuration = configuration
+		self.leases = leases
+
+		if self.configuration.provision_self:
+			for ip in self.ip:
+				self.leases.IP.lease(ip, self.mac)
+				self.leases.MAC.lease(self.mac, ip)
+
+		self.initiate()
+
+	@property
+	def mac(self):
+		with open(f'/sys/class/net/{self.configuration.interface}/address', 'r') as fh:
+			return fh.read().strip()
+
+	@property
+	def ip(self):
+		for ip, network in get_network_interfaces().get(self.configuration.interface).items():
+			yield ip
+
+	def initiate(self):
 		self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(ETH_P_ALL))
 		self.socket.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
-		promisciousMode = promisc(self.socket, bytes(kwargs['interface'], 'UTF-8'))
-		promisciousMode.on()
+		self.promisciousMode = promisc(self.socket, bytes(self.configuration.interface, 'UTF-8'))
+		self.promisciousMode.on()
 
 		self.main_so_id = self.socket.fileno()
-		print(f'[-] Bound to: {{"interface" : "{kwargs["interface"]}", "address" : "{kwargs["bind_to"]}", "port" : 67}}')
 
 		self.pollobj = epoll()
 		self.pollobj.register(self.main_so_id, EPOLLIN)
 
+	def close(self):
+		self.promisciousMode.off()
+		self.pollobj.unregister(self.main_so_id)
+		self.socket.close()
+
+	def is_alive(self):
+		return True
 
 	def poll(self, timeout=0.001, fileno=None):
 		d = dict(self.pollobj.poll(timeout))
 		if fileno: return d[fileno] if fileno in d else None
 		return d
 
-	def close(self):
-		self.pollobj.unregister(self.main_so_id)
-		self.socket.close()
-
-	def get_lease(self, mac):
-		if mac in self.lease_db.leases_by_mac:
-			return self.lease_db.leases_by_mac[mac]
-		else:
-			return None
-
-	def parse(self):
-		# The struct just maps how many bytes (not bits) per section in a DHCP request.
-		# A graphic overview can be found here: https://tools.ietf.org/html/rfc2131#section-2
-		dhcp_packet_struct = [1, 1, 1, 1, 4, 2, 2, 4, 4, 4, 4, 6, 10, 64, 128, 4]
-		# We then use that struct map to place the values into a dictionary with these keys (in order):
-		dhcp_protocol = ['msg type', 'hw type', 'hw addr len', 'hops',
-						 'transaction id',
-						 'elapsed', 'bootp flags',
-						 'client ip',
-						 'client assigned ip',
-						 'server ip',
-						 'relay agent',
-						 'client mac',
-						 'client padding',
-						 'server hostname',
-						 'boot file',
-						 'magic cookie',
-						 #'option 53', # This is dangerous to assume
-						 'options']
-
+	def get_frame(self):
 		if self.poll():
 			data, auxillary_data_raw, flags, addr = self.socket.recvmsg(65535, socket.CMSG_LEN(4096))
 
-			if not data:
-				return
+			auxillary_items = []
+			for message_level, message_type, message_data in auxillary_data_raw:
+				if message_level == SOL_PACKET and message_type == PACKET_AUXDATA:
+					auxdata = tpacket_auxdata.from_buffer_copy(message_data)
+					auxillary_items.append(
+						AuxillaryItem(**{
+							'status' : auxdata.tp_status,
+							'length' : auxdata.tp_len,
+							'snap_length' : auxdata.tp_snaplen,
+							'mac' : auxdata.tp_mac,
+							'net' : auxdata.tp_net,
+							'vlan' : auxdata.tp_vlan_tci,
+							'padding' : auxdata.tp_padding
+						})
+					)
 
-			auxillary_data = []
-			if auxillary_data_raw:
-				auxillary_data = list(parse_auxillary_data(auxillary_data_raw))[0]
+			try:
+				return Frame(server=self, request=data, auxillary_data=auxillary_items, auxillary_data_raw=auxillary_data_raw, flags=flags, addr=addr)
+			except (NonDHCPFrame, NonIPv4Frame, NonBroadcastFrame, InvalidFrameLength):
+				# Promiscious socket simply picked up another frame
+				pass
+			#except pydantic.error_wrappers.ValidationError:
+			#	pass
+			#except Exception as error:
+			#	print(f"Invalid DHCP Frame: {error}\nOn data: {data}")
 
-			ethernet_data = data[0:14]
-			ethernet_segments = struct.unpack("!6s6s2s", ethernet_data)
+	def respond(self, response :FrameResponse):
+		# If the 'giaddr' field in a DHCP message from a client is non-zero,
+		# the server sends any return messages to the 'DHCP server' port on the
+		# BOOTP relay agent whose address appears in 'giaddr'. If the 'giaddr'
+		# field is zero and the 'ciaddr' field is nonzero, then the server
+		# unicasts DHCPOFFER and DHCPACK messages to the address in 'ciaddr'.
+		# If 'giaddr' is zero and 'ciaddr' is zero, and the broadcast bit is
+		# set, then the server broadcasts DHCPOFFER and DHCPACK messages to
+		# 0xffffffff. If the broadcast bit is not set and 'giaddr' is zero and
+		# 'ciaddr' is zero, then the server unicasts DHCPOFFER and DHCPACK
+		# messages to the client's hardware address and 'yiaddr' address.  In
+		# all cases, when 'giaddr' is zero, the server broadcasts any DHCPNAK
+		# messages to 0xffffffff.
+		
+		# if self.bind_to == '255.255.255.255':
+		print(f"[-] Broadcasting back response")
+		self.socket.sendmsg([response.frame.data], response.frame.request_frame.auxillary_data_raw, response.frame.request_frame.flags, ('255.255.255.255', 68))
+		# else:
+		# 	print(f"[-] Sending directly to {addr}")
+		# 	self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)
 
-			mac_dest, mac_source = (binascii.hexlify(mac) for mac in ethernet_segments[:2])
-			mac_source = b':'.join(mac_source[i:i+2] for i in range(0, len(mac_source), 2))
-			mac_dest = b':'.join(mac_dest[i:i+2] for i in range(0, len(mac_dest), 2))
-			frame_type = binascii.hexlify(ethernet_segments[2])
+		# if self.cache_db:
+		# 	self.lease_db.save(self.cache_dir + '/' + self.cache_db)
+		# 	#save_local_storage(self.cache_dir + '/' + self.cache_db, self.lease_db)
 
-			ip = data[14:34]
-			ip_segments = struct.unpack("!12s4s4s", ip)
+class IPLeases(pydantic.BaseModel):
+	__root__: Dict[str, str]
 
-			ip_source, ip_dest = (socket.inet_ntoa(section) for section in ip_segments[1:3])
+	def __contains__(self, key):
+		if type(key) == bytes:
+			key = key.decode('utf-8')
+		if type(key) == str:
+			key = ipaddress.IPv4Address(key)
+		return key in self.__root__
 
-			udp_data = data[34:42]
-			udp_segments = struct.unpack("!hhh2s", udp_data)
-			source_port, destination_port, udp_payload_len, udp_checksum = udp_segments
+	def __getitem__(self, item):
+		if type(item) == bytes:
+			item = item.decode('utf-8')
+		if type(item) == str:
+			item = ipaddress.IPv4Address(item)
 
-			# IPv4 == \x08\x00
-			if frame_type != b'0800':
-				return
+		return self.__root__[item]
 
-			if not mac_dest == b'ff:ff:ff:ff:ff:ff':
-				# We only accept broadcasts
-				return
+	def lease(self, ip, mac):
+		self.__root__[ip] = mac
 
-			if destination_port != 67:
-				return
+class MACLeases(pydantic.BaseModel):
+	__root__: Dict[str, str]
 
-			# print('MAC Source:', mac_source)
-			# print('MAC Dest:', mac_dest)
-			# print('Frame Type:', frame_type)
-			# print(auxillary_data)
-			# print(binascii.hexlify(data))
+	def __contains__(self, key):
+		return key in self.__root__
 
-			# print('IP Source:', ip_source)
-			# print('IP Dest:', ip_dest)
+	def __getitem__(self, item):  # if you want to use '[]'
+		return self.__root__[item]
 
-			# print('UDP:', source_port, destination_port)
+	def lease(self, mac, ip):
+		self.__root__[mac] = ip
 
-			## Convert and slot the data into the binary map representation
-			binary = list(byte_to_bin(data[42:], bin_map=dhcp_packet_struct))
+class Leases(pydantic.BaseModel):
+	IP: IPLeases
+	MAC: MACLeases
 
-			## Convert the binary representation into the protocol map
-			request = {}
-			for index in range(len(binary)):
-				request[dhcp_protocol[index]] = {'binary' : binary[index], 'bytes' : bin_str_to_byte(binary[index]), 'hex' : None}
-				request[dhcp_protocol[index]]['hex'] = bytes_to_hex(request[dhcp_protocol[index]]['bytes'])
+class Filters(pydantic.BaseModel):
+	# https://github.com/samuelcolvin/pydantic/issues/1802
+	__root__: Dict[str, Union[str, bool]]
 
-			print(f'[+] Request from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
-			if str(bytes_to_ip(request['relay agent']['bytes'])) != addr[0]:
-				if self.valid_relays.get(addr[0]) != str(bytes_to_ip(request['relay agent']['bytes'])):
-					print(f"[!] Inconsistency in relayed message, sender is not the same as the relay IP: Sender={addr[0]}, Relay-Agent={bytes_to_ip(request['relay agent']['bytes'])} ")
-					return None
-			print(f"[ ]  Relay via {bytes_to_ip(request['relay agent']['bytes'])}")
+	class Config:
+		smart_union = True
 
-			## Check if we've white listed clients,
-			## and if so, check if this client isn't allowed and return nothing on the cable.
-			if 'filter_clients' in args and args['filter_clients']:
-				if not bytes_to_mac(request["client mac"]["bytes"]) in args['filter_clients']:
-					print(f'[ ] Request ignored: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}"}}')
-					return
+class PXEConfiguration(pydantic.BaseModel):
+	binary: pathlib.Path
+	next_server: ipaddress.IPv4Network
+	directory: pathlib.Path = pathlib.Path('/srv/pxe/')
 
-			# Build the remaining DHCP options by checking type, length and structuring data.
-			pos = 0
-			request['dhcp_options'] = {}
-			while pos < len(data) and pos <= 312:
-				option = request['options']['bytes'][pos]
-				if option == 255: # End
-					break
-				length = request['options']['bytes'][pos+1]
-				if pos + 2 + length > len(data):
-					# out of bounds check
-					break
-				data = request['options']['bytes'][pos+2:pos+2+length]
-				pos += 2 + length
+class DHCPSpecifics(pydantic.BaseModel):
+	subnet: ipaddress.IPv4Network
+	gateway: Optional[ipaddress.IPv4Address] = None
+	pxe: Optional[PXEConfiguration] = None
+	dns_servers: Optional[List[ipaddress.IPv4Address]] = None
 
-				request['dhcp_options'][f"option {option}"] = { 'binary' : None,
-																'bytes' : data}
+class Configuration(pydantic.BaseModel):
+	interface: str
+	dhcp: DHCPSpecifics
+	provision_self: Optional[bool] = False
+	filters: Optional[Filters] = None
+	leases: pathlib.Path = pathlib.Path('./leases.json')
 
-			## Got all the parsing and processing done.
-			## Time ot build a response if the requested packet was DHCP request of some kind.
-			packet = b''
-			if request['msg type']['bytes'][-1] == 1: # Message type: Boot request (1)
-				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[ ] DHCP Discover from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "type" : "DHCP_DISCOVER"}}')
-				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[ ] DHCP Request for IP from: {{"mac": "{bytes_to_mac(request["client mac"]["bytes"])}", "ip" : "<ignored>", "type" : "DHCP_REQUEST"}}')
-
-				## Check lease time for the specific mac
-				## If we don't find a lease, begin the "generate new IP process".
-				mac = bytes_to_mac(request["client mac"]["bytes"])
-				if not (leased_ip := self.get_lease(mac)):
-					# The mac is filtered, and contains a static IP lease definition
-					if args['filter_clients'] and mac in args['filter_clients'] and args['filter_clients'][mac].count('.'):
-						leased_ip = ipaddress.ip_address(args['filter_clients'][mac])
-						print(f'[ ] Staticly giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "STATIC_DHCP_OFFER"}}')
-					# Otherwise, generate a IP from the total pool of available IP's
-					else:
-						leased_ip = self.lease_db.available_ip
-						print(f'[ ] Dynamically giving: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "DYNAMIC_DHCP_OFFER"}}')
-					
-					if leased_ip:
-						self.lease_db.lease(leased_ip, mac)
-						#self.lease_db.leases_by_mac[mac] = leased_ip
-						#self.lease_db.leases_by_ip[leased_ip] = mac
-					else:
-						raise ValueError('TODO: Out of IP addresses..') # TODO: make a clean "continue" / "check if old leases expired"
-				# There was a pre-existing lease, using that lease:
-				else:
-					print(f'[ ] Giving cached: {{"ip" : "{leased_ip}", "to" : "{mac}", "type" : "CACHED_DHCP_OFFER"}}')
-
-				# Assemble the packet headers
-				packet += ethernet(src=b'00:51:82:11:22:00', dst=mac_source) + b'\x81\x00'
-				packet += struct.pack('>h', 0b0000000000000010) + b'\x08\x00'# vlan(struct.pack('>h', 0b0000000000000010) + b'\x08\x00')
-				packet += ipv4(src='172.23.0.1', dst='255.255.255.255')
-				packet += udp(src=67, dst=68)
-
-				# Assemble the DHCP specific payload
-				packet += dhcp_option.dhcp_offer()
-				packet += dhcp_option.hardware_type('ethernet')
-				packet += dhcp_option.hardware_address_length(6)
-				packet += dhcp_option.hops(request['hops']['bytes'][0]+1)
-				packet += dhcp_option.trasnaction_id(request)
-				packet += dhcp_option.seconds_elapsed(0)
-				packet += dhcp_option.bootp_flags(request)
-				packet += dhcp_option.client_ip(request, self)
-				packet += dhcp_option.offered_ip(leased_ip)
-				packet += dhcp_option.next_server(self.pxe_server) # 0.0.0.0 == None
-				packet += dhcp_option.relay_agent(bytes_to_ip(request['relay agent']['bytes']))
-				packet += dhcp_option.client_mac(request)
-				packet += dhcp_option.client_addr_padding()
-				packet += dhcp_option.server_host_name(request)
-				packet += b'\x00' * 128 # TODO: Unknown
-				packet += dhcp_option.magic_cookie()
-
-				## This is basically what differs in a basic basic DHCP sequence,
-				## the message type recieved and matching response. At least for a basic IP request/handshake.
-				if request['dhcp_options']['option 53']['bytes'][-1] == 1: # DHCP Discover
-					print(f'[-] Sending: {{"type" : "OFFER", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
-					packet += dhcp_option.TYPE('OFFER')
-				if request['dhcp_options']['option 53']['bytes'][-1] == 3: # DHCP Request
-					print(f'[-] Sending: {{"type" : "PROVIDED", "to" : "{mac}", "offering" : "{self.lease_db.leases_by_mac[mac]}"}}')
-					packet += dhcp_option.TYPE('ACK')
-				
-				# Slap on the clients trasnacation identifier so it knows
-				# we responded to the request and not some other request it made.	
-				packet += dhcp_option.identifier(self.bind_to)
-				
-				# We don't honor these, so we're generous with them:
-				packet += dhcp_option.lease_time(43200)
-				packet += dhcp_option.renewal_time(21600)
-				packet += dhcp_option.rebind_time(37800)
-
-				# And the IP, subnet, router(gateway) and DNS information.
-				packet += dhcp_option.subnet(self.subnet.netmask)
-				packet += dhcp_option.broadcast_addr(self.subnet.broadcast_address)
-				packet += dhcp_option.router(self.gateway)
-				packet += dhcp_option.dns_servers(*self.dns_servers)
-
-				# If we have a PXE binary to deliver, add the appropriate options to the request:
-				if self.pxe_bin:
-					packet += dhcp_option.tftp_server_name(self.gateway)
-					packet += dhcp_option.boot_file(self.pxe_bin)
-					packet += dhcp_option.boot_file_prefix(self.pxe_dir)
-					packet += dhcp_option.boot_file_configuration(self.pxe_config)
-
-				packet += b'\xff'   #End Option
-
-			if len(packet) > 0:
-				# If the 'giaddr' field in a DHCP message from a client is non-zero,
-				# the server sends any return messages to the 'DHCP server' port on the
-				# BOOTP relay agent whose address appears in 'giaddr'. If the 'giaddr'
-				# field is zero and the 'ciaddr' field is nonzero, then the server
-				# unicasts DHCPOFFER and DHCPACK messages to the address in 'ciaddr'.
-				# If 'giaddr' is zero and 'ciaddr' is zero, and the broadcast bit is
-				# set, then the server broadcasts DHCPOFFER and DHCPACK messages to
-				# 0xffffffff. If the broadcast bit is not set and 'giaddr' is zero and
-				# 'ciaddr' is zero, then the server unicasts DHCPOFFER and DHCPACK
-				# messages to the client's hardware address and 'yiaddr' address.  In
-				# all cases, when 'giaddr' is zero, the server broadcasts any DHCPNAK
-				# messages to 0xffffffff.
-				if self.bind_to == '255.255.255.255':
-					print(f"[-] Broadcasting back response")
-					self.socket.sendmsg([packet], auxillary_data_raw, flags, ('255.255.255.255', 68))
-				else:
-					print(f"[-] Sending directly to {addr}")
-					self.socket.sendmsg([packet], auxillary_data_raw, flags, addr)
-
-				if self.cache_db:
-					self.lease_db.save(self.cache_dir + '/' + self.cache_db)
-					#save_local_storage(self.cache_dir + '/' + self.cache_db, self.lease_db)
 
 if __name__ == '__main__':
-	instances = []
+	instance = None
+	leases = {'IP': {}, 'MAC' : {}}
+	Frame.update_forward_refs()
 
 	def sig_handler(signal, frame):
-		for instance in instances:
+		if instance:
 			instance.close()
 		exit(0)
 	signal.signal(signal.SIGINT, sig_handler)
 
-	## Basic version of arg.parse() supporting:
-	## * --key=value
-	## * slimDHCP.py positional1 positional2
-	args = {}
-	positionals = []
-	for arg in sys.argv[1:]:
-		if '--' == arg[:2]:
-			if '=' in arg:
-				key, val = [x.strip() for x in arg[2:].split('=')]
+	parser = argparse.ArgumentParser()
+	# Either load options via config
+	parser.add_argument("--config", nargs="?", help="JSON configuration file or URL", type=pathlib.Path)
+	# and/or override with arguments
+	parser.add_argument("--interface", nargs="?", help="Interface to bind to.", type=str)
+	parser.add_argument("--leases", nargs="?", help="Path to the JSON lease database", type=pathlib.Path, default=pathlib.Path('/srv/dhcp/leases.db').resolve())
+	parser.add_argument("--subnet", nargs="?", help="Subnet with CIDR notation, example 192.168.0.0/24", type=ipaddress.IPv4Network)
+	parser.add_argument("--gateway", nargs="?", help="IPv4 address to the default gateway", type=ipaddress.IPv4Address)
+	parser.add_argument("--dns-servers", nargs="?", help="comma separated list of DNS servers", type=str)
+	parser.add_argument("--pxe-server", nargs="?", help="The next server that facilitates the PXE binaries", type=ipaddress.IPv4Address)
+	parser.add_argument("--pxe-binary", nargs="?", help="The binary to tell the client to load", type=pathlib.Path)
+	parser.add_argument("--pxe-directory", nargs="?", help="The root of the exposed PXE directory", type=pathlib.Path)
+	parser.add_argument("--filters", nargs="?", help="A JSON structure of filters, example: '{\"de:ad:be:ef:00:01\" : true, \"de:ad:be:ef:00:02\" : \"192.168.1.10\"}'\nYou cannot mix True or False, True will only let through the items in the list and block by default. False will let everything through by default but block the specified hosts.", type=str)
+	parser.add_argument("--valid-relays", nargs="?", help="A comma separated list of valid relay servers (if found in frames)", type=str)
+	parser.add_argument("--provision-self", action='store_true', help="A comma separated list of valid relay servers (if found in frames)", default=False)
+
+	config = {}
+	args, unknowns = parser.parse_known_args()
+	# preprocess the json files.
+	# TODO Expand the url access to the other JSON file arguments ?
+	if args.config is not None:
+		try:
+			# First, let's check if this is a URL scheme instead of a filename
+			parsed_url = urllib.parse.urlparse(args.config)
+
+			if not parsed_url.scheme:
+				with args.config.resolve().open('r') as fh:
+					config = json.load(fh)
 			else:
-				key, val = arg[2:], True
-			args[key] = val
-		else:
-			positionals.append(arg)
+				with urllib.request.urlopen(urllib.request.Request(args.config, headers={'User-Agent': 'ArchInstall'})) as response:
+					config = json.loads(response.read())
+		except Exception as e:
+			raise ValueError(f"Could not load --config because: {e}")
 
-	if not 'interface' in args:
-		print('\n  [!] Mandatory: --interface=<ifname>') #args['interface'] = 'ens4u1u4'
-		print()
-		print('Usage: ')
-		print(' --interface=eth0          (mandatory)')
-		print(' --subnet=192.168.1.0/24   (default)')
-		print(' --gateway=192.168.1.1     (default is the first ip on --interface)')
-		print(' --pxe_bin=ipxe.efi')
-		print(' --pxe_dir=/srv/pxe/')
-		print(' --filter_clients=\'{"de:ad:be:ef:00:01" : true, "de:ad:be:ef:00:02" : "192.168.1.10"}\'')
-		exit(1)
-	
-	if not 'cache_dir' in args: args['cache_dir'] = './'
-	if not 'cache_db' in args: args['cache_db'] = None
-	if not 'subnet' in args: args['subnet'] = None
-	if not 'netmask' in args: args['netmask'] = '255.255.255.0' # Optional, if it's given on the subnet definition.
-	if not 'gateway' in args: args['gateway'] = None # Takes the first host of the subnet by default
-	if not 'is_gateway' in args: args['is_gateway'] = False
-	if not 'dns_servers' in args: args['dns_servers'] = ('8.8.8.8', '4.4.4.4')
-	if not 'pxe_bin' in args: args['pxe_bin'] = None # Point toward a efi file, for instance: '/ipxe.efi'
-	if not 'pxe_dir' in args: args['pxe_dir'] = './'# './pxe_files'
-	if not 'pxe_config' in args: args['pxe_config'] = 'loader/loader.conf'
-	if not 'multi_bind' in args: args['multi_bind'] = True
-	if not 'valid_relays' in args: args['valid_relays'] = '{}'
-	if not 'pxe_server' in args: args['pxe_server'] = '0.0.0.0'
-	if not 'filter_clients' in args: args['filter_clients'] = '{}' # JSON structure of clients
-	args['valid_relays'] = json.loads(args['valid_relays'])
+	if args.interface:
+		config['interface'] = args.interface
+	if args.leases:
+		config['leases'] = args.leases
+	if args.subnet:
+		config['subnet'] = args.subnet
+	if args.gateway:
+		config['gateway'] = args.gateway
+	if args.dns_servers:
+		config['dns_servers'] = args.dns_servers
+	if args.pxe_server:
+		config['pxe_server'] = args.pxe_server
+	if args.pxe_binary:
+		config['pxe_binary'] = args.pxe_binary
+	if args.pxe_directory:
+		config['pxe_directory'] = args.pxe_directory
+	if args.filters:
+		config['filters'] = args.filters
+	if args.valid_relays:
+		config['valid_relays'] = args.valid_relays
+	if args.provision_self:
+		config['provision_self'] = args.provision_self
 
-	if not args['gateway'] and args['is_gateway']:
-		args['gateway'] = get_ip_address(args['interface'])
-		if not args['gateway']:
-			raise ValueError(f"slimDHCP could not detect a valid IP address on {args['interface']}, and --is_gateway was given, which requires us to be able to recieve traffic. This in turn means we can't guess a subnet to use.")
-	if args['multi_bind'] and get_ip_address(args['interface']) is None:
-		raise ValueError(f"slimDHCP was asked to bind to multiple IP's, however the interface doesn't have an IP which means we can only listen to broadcast traffic. Either do not attempt --multi_bind or assign a valid IP to the --interface {args['interface']}")
+	if not config.get('interface'):
+		raise ValueError(f"Need to supply --interface (or 'interface' via --config)")
 
-	if not args['subnet'] and not args['gateway']:
-		args['subnet'] = '192.168.1.0'
-	elif not args['subnet']:
-		ip_information = get_network_interfaces().get(args['interface'], {})
-		first_available_ip = list(ip_information.keys())[0]
-		matching_subnet_mask = ip_information[first_available_ip]
-		args['subnet'] = str(ipaddress.ip_network(f"{first_available_ip}/{matching_subnet_mask}", strict=False).network_address)
-		if args['netmask'] != matching_subnet_mask:
-			raise ValueError(f"A subnet was autodetected as {args['subnet']}, but the autodetected netmask of {matching_subnet_mask} does not match the user specified --netmask.")
+	config['dhcp'] = {'subnet' : config.get('subnet')}
+	if config.get('gateway'):
+		config['dhcp']['gateway'] = config['gateway']
+	if config.get('pxe'):
+		config['dhcp']['pxe'] = config['pxe'] #TODO: Convert into a dict struct for parsing
+	if config.get('dns_servers'):
+		config['dhcp']['dns_servers'] = config['dns_servers'].split(',')
 
-	## Convert arguments to workable elements:
-	if type(args['dns_servers']) == str:
-		args['dns_servers'] = json.loads(args['dns_servers'])
-	if type(args['subnet']) == str:
-		## Append the netmask/cidr on to the subnet definition if not already given.
-		if not '/' in args['subnet']: args['subnet'] = f"{args['subnet']}/{args['netmask']}"
-		args['subnet'] = ipaddress.ip_network(args['subnet'])
-	if type(args['pxe_server']) == str:
-		args['pxe_server'] = ipaddress.ip_address(args['pxe_server'])
-
-	if type(args['filter_clients']) == str:
-		args['filter_clients'] = json.loads(args['filter_clients'])
-
-	# Designate a gateway if none was given, take the first host of our subnet element:
-	if not args['gateway']:
-		for host in args['subnet'].hosts():
-			args['gateway'] = host
+	if not config['dhcp']['subnet']:
+		# Attempt to autodetect the network + netmask for the given --interface
+		# and use that as our --subnet if none was given.
+		for ip, network in get_network_interfaces().get(config['interface']).items():
+			config['dhcp']['subnet'] = network
 			break
 
-	lease_database = Leases(args['subnet'])
-	if args['cache_dir'] and args['cache_db']:
-		lease_database.load(f"{args['cache_dir']}/{args['cache_db']}")
+	if args.filters:
+		config['filters'] = Filters.parse_obj(json.loads(args.filters))
 
+	config = Configuration(**config)
+
+	if (iface_ip := get_ip_address(config.interface)) and iface_ip in config.dhcp.subnet:
+		# If our interface has an IP in the DHCP subnet range,
+		# that means we should avoid giving it out and provision it
+		# to ourselves to avoid conflicts.
+		# (The actual provisioning happens later)
+		config.provision_self = True
+
+	if config.provision_self and iface_ip is None:
+		raise ValueError(f"You've indicated that we have an IP on the interface with --provision-self but no IP found on {config.interface}")
+
+	if config.leases and config.leases.resolve().exists():
+		with config.leases.resolve().open('r') as fh:
+			leases = Leases(json.loads(fh.read()))
+
+	instance = DHCPServer(config, Leases(**leases))
+	while instance.is_alive():
+		if frame := instance.get_frame():
+			instance.respond(frame.response())
+
+	"""
 	if args['multi_bind']:
 		instances.append(dhcp_serve(lease_db=lease_database, bind_to=get_ip_address(args['interface']), **{**args, 'gateway' : get_ip_address(args['interface'])}))
 	instances.append(dhcp_serve(lease_db=lease_database, bind_to='255.255.255.255', **args))
@@ -1056,3 +1493,4 @@ if __name__ == '__main__':
 		for instance in instances:
 			if instance.poll():
 				instance.parse()
+	"""

--- a/slimDHCP.py
+++ b/slimDHCP.py
@@ -1090,6 +1090,7 @@ class FrameResponse(pydantic.BaseModel):
 		packet += dhcp_fields.hardware_type('ethernet')
 		packet += dhcp_fields.hardware_address_length(6)
 		packet += dhcp_fields.hops(frame.request.hops)
+		print('Responding to:', frame.request.transaction_id)
 		packet += dhcp_fields.transaction_id(frame.request.transaction_id)
 		packet += dhcp_fields.seconds_elapsed(0)
 		# https://www.ietf.org/rfc/rfc2131.txt
@@ -1120,13 +1121,13 @@ class FrameResponse(pydantic.BaseModel):
 		elif frame.request.options.option_53.data == 3: # DHCP Request
 			packet += dhcp_fields.TYPE('ACK')
 
-		packet += dhcp_fields.server_identifier('172.22.0.2')
+		packet += dhcp_fields.server_identifier('192.168.0.1')
 		packet += dhcp_fields.lease_time(43200)
 		packet += dhcp_fields.renewal_time(21600)
 		packet += dhcp_fields.rebind_time(37800)
 		packet += dhcp_fields.subnet('255.255.255.0')
-		packet += dhcp_fields.broadcast_addr('172.22.0.255')
-		packet += dhcp_fields.router('172.22.0.1')
+		packet += dhcp_fields.broadcast_addr('192.168.0.255')
+		packet += dhcp_fields.router('192.168.0.1')
 		packet += dhcp_fields.dns_servers('8.8.8.8', '4.4.4.4')
 		packet += b'\xff'   #End Option
 


### PR DESCRIPTION
Using a promiscuous socket is strictly speaking not needed, but it helps a bit.
Parsing of ethernet, 802.1Q, IP and UDP headers are done manually, and reconstruction is also done manually.
The use of socket `recvmsg` and `sendmsg` is key here to facilitate the parsing of vlan data, as it gets mangled by the NIC into auxiliary data via control messages to the kernel (TCI?).
More on that here: https://developerweb.net/viewtopic.php?id=7396 and https://stackoverflow.com/questions/56653023/reading-vlan-field-of-a-raw-ethernet-packet-in-python